### PR TITLE
terraform: add plan-refresh and apply-refresh to Makefile

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -74,6 +74,14 @@ plan: prep ## Show what terraform thinks it will do
 		-refresh=true \
 		-var-file="$(VARS)"
 
+.PHONY: plan-refresh
+plan-refresh: prep ## Show what terraform thinks it will do, as a refresh-only operation against tfstate
+	@terraform plan \
+		-lock=true \
+		-input=false \
+		-refresh-only \
+		-var-file="$(VARS)"
+
 .PHONY: plan-target
 plan-target: prep ## Shows what a plan looks like for applying a specific resource
 	@echo "$(YELLOW)$(BOLD)[INFO]   $(RESET)"; echo "Example to type for the following question: module.gke.google_container_cluster.cluster"
@@ -120,6 +128,14 @@ apply-bootstrap: prep ## Have terraform bring up the minimal resources needed to
 		-target=module.gke \
 		-target=module.eks
 	echo "If that succeeded, run 'terraform output --json | (cd ../deploy-tool/ ; go run main.go )'"
+
+.PHONY: apply-refresh
+apply-refresh: prep ## Have terraform do the things as a refresh-only operation against tfstate. This may or may not cost money.
+	@terraform apply \
+		-lock=true \
+		-input=false \
+		-refresh-only \
+		-var-file="$(VARS)"
 
 .PHONY: destroy-bootstrap
 destroy-bootstrap: prep ## Have terraform destroy the resources brought up by apply-bootstrap

--- a/terraform/state-surgery/README.md
+++ b/terraform/state-surgery/README.md
@@ -101,6 +101,17 @@ Finally, check `terraform plan` output to make sure it is as expected.
 
     ENV=<env> TF_VAR_aws_profile=<profile> make plan
 
+If terraform emits a message about minor deviations in non-critical pieces of
+the state, like:
+
+   `~ resource_version = "156735235" -> "156738850"`
+
+and suggests providing the `-refresh-only` flag to `plan` and `apply`, then
+utilize the `plan-refresh` and `apply-refresh` `make` tarets to update the
+remote state.
+
+    ENV=<env> TF_VAR_aws_profile=<profile> make apply-refresh
+
 And now we can work with the doctored state as normal, using the `plan` and
 `apply` `make` targets.
 


### PR DESCRIPTION
These supply the -refresh-only option to their respective (plan|apply)
terraform commands. Use these when the infrastructure state matches the
terraform state, but terraform suggests a refresh to pickup minor
changes which may have been applied outside of terraform.