### PR TITLE
Fix makefile quoting

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -11,16 +11,16 @@ $(info $(BOLD)Example usage: \`ENV=demo make plan\`$(RESET))
 $(error $(BOLD)$(RED)ENV was not set$(RESET))
 endif
 
-VARS="variables/$(ENV).tfvars"
-REGION="$(shell grep '^gcp_region' $(VARS) | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
+VARS=variables/$(ENV).tfvars
+REGION="$(shell grep '^gcp_region' "$(VARS)" | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
 ifeq ($(REGION),"")
 $(error $(BOLD)$(RED)REGION was not detected$(RESET))
 endif
-PROJECT="$(shell grep '^gcp_project' $(VARS) | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
+PROJECT="$(shell grep '^gcp_project' "$(VARS)" | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
 ifeq ($(PROJECT),"")
 $(error $(BOLD)$(RED)PROJECT was not detected$(RESET))
 endif
-STATE_BUCKET="$(shell grep '^state_bucket' $(VARS) | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
+STATE_BUCKET="$(shell grep '^state_bucket' "$(VARS)" | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
 ifeq ($(STATE_BUCKET),"")
 $(error $(BOLD)$(RED)STATE_BUCKET was not detected$(RESET))
 endif

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -13,15 +13,15 @@ endif
 
 VARS="variables/$(ENV).tfvars"
 REGION="$(shell grep '^gcp_region' $(VARS) | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
-ifeq ($(REGION),)
+ifeq ($(REGION),"")
 $(error $(BOLD)$(RED)REGION was not detected$(RESET))
 endif
 PROJECT="$(shell grep '^gcp_project' $(VARS) | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
-ifeq ($(PROJECT),)
+ifeq ($(PROJECT),"")
 $(error $(BOLD)$(RED)PROJECT was not detected$(RESET))
 endif
 STATE_BUCKET="$(shell grep '^state_bucket' $(VARS) | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
-ifeq ($(STATE_BUCKET),)
+ifeq ($(STATE_BUCKET),"")
 $(error $(BOLD)$(RED)STATE_BUCKET was not detected$(RESET))
 endif
 


### PR DESCRIPTION
This fixes some issues with quoting of variables in the Makefile. The first commit fixes the input validation conditionals, which would have previously been comparing the empty string to `""`. The second commit avoids wrapping the path to the variables file in two sets of double quotes, for consistency.