### PR TITLE
terraform: Upgrade aws-for-fluent-bit container

### DIFF
--- a/terraform/modules/eks/log.tf
+++ b/terraform/modules/eks/log.tf
@@ -172,7 +172,7 @@ resource "kubernetes_daemonset" "fluent_bit" {
 
         container {
           name              = "fluent-bit"
-          image             = "amazon/aws-for-fluent-bit:2.10.0"
+          image             = "amazon/aws-for-fluent-bit:2.23.1"
           image_pull_policy = "Always"
 
           env {


### PR DESCRIPTION
The fluent-bit DaemonSet was previously running an old version of this image, which included Fluent Bit 1.6. That version did not support the `log_retention_days` configuration parameter for the `cloudwatch_logs` plugin, and thus it would fail to start. Upgrading the container brings the Fluent Bit version to 1.8, which does support this parameter.