### PR TITLE
Add alert rules for unhealthy containers

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -135,3 +135,21 @@ groups:
     annotations:
       summary: "prometheus-server low disk space"
       description: "There is less than 30% available disk space on the prometheus-server PersistentVolumeClaim"
+  - alert: kubernetes_pod_restarting
+    expr: increase(kube_pod_container_status_restarts_total[15m]) > 2
+    labels:
+      severity: page
+      environment: ${environment}
+    annotations:
+      summary: "Container is in a restart loop"
+      description: "Container {{ $labels.container }} is restarting repeatedly in
+        pod {{ $labels.pod }}, namespace {{ $labels.namespace }}, and environment ${environment}."
+  - alert: kubernetes_pod_waiting
+    expr: min_over_time(kube_pod_container_status_waiting_reason[15m]) > 0
+    labels:
+      severity: page
+      environment: ${environment}
+    annotations:
+      summary: "Container is stuck waiting"
+      description: "Container {{ $labels.container }} has been waiting for fifteen minutes, in pod
+        {{ $labels.pod }}, namespace {{ $labels.namespace }}, and environment ${environment}."


### PR DESCRIPTION
This adds two partly overlapping alerting rules using `kube-state-metrics` data. The first checks for containers that restart repeatedly, and the second checks for containers that are waiting for one reason for an extended period of time. These will catch `CrashLoopBackOff` and `ImagePullBackOff` conditions, as well as `restartPolicy: Always` containers that exit with a success code quickly.