### PR TITLE
Revise container alerting rules

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -136,7 +136,8 @@ groups:
       summary: "prometheus-server low disk space"
       description: "There is less than 30% available disk space on the prometheus-server PersistentVolumeClaim"
   - alert: kubernetes_pod_restarting
-    expr: increase(kube_pod_container_status_restarts_total[15m]) > 2
+    expr: (increase(kube_pod_container_status_restarts_total[15m]) * on (exported_namespace, pod) group_left kube_pod_info) > 2
+    for: 5m
     labels:
       severity: page
       environment: ${environment}
@@ -145,7 +146,7 @@ groups:
       description: "Container {{ $labels.container }} is restarting repeatedly in
         pod {{ $labels.pod }}, namespace {{ $labels.namespace }}, and environment ${environment}."
   - alert: kubernetes_pod_waiting
-    expr: min_over_time(kube_pod_container_status_waiting_reason[15m]) > 0
+    expr: min_over_time(kube_pod_container_status_waiting[15m]) * kube_pod_container_status_waiting * (kube_pod_container_status_waiting offset 15m) > 0
     labels:
       severity: page
       environment: ${environment}


### PR DESCRIPTION
The two new container alerting rules I added this week had false positive problems, of different magnitudes. Both related to the rules' behavior when label sets were absent.

I have re-tested the rules, and they appear to be working correctly now. I did positive testing against broken pods stuck in CrashLoopBackOff and ImagePullBackOff in my development environment, and the rules still work against those. I did negative testing against prod-us by graphing the same rules against its TSDB, and both have no label sets above the threshold over the past several hours' of data.

## kubernetes_pod_waiting

This rule had more severe false positives. The original rule was `min_over_time(kube_pod_container_status_waiting_reason[15m]) > 0`. The metric kube_pod_container_status_waiting_reason is a gauge, and it appears the metric takes a value of 1 for label sets corresponding to any waiting container, while emitting no label sets for any non-waiting container. This is thus an "info metric". I have changed this rule to use kube_pod_container_status_waiting instead, another gauge, which exports a 0 or 1 for each container. Additionally, just taking min_over_time() on the metric may trigger on job containers. If the exporter sees a job container during a brief window when it is in ContainerCreating during one scrape, the job completes, and then the exporter sees no label sets for the container during the next scrape, then min_over_time() will return 1 for this container's label set, even though the job has completed normally. Thus, the rule now multiplies by two instant vectors, one at each end of the fifteen minute window, so that we will only see label sets for which the container has existed for at least fifteen minutes, and has been waiting for at least that long as well. I missed this issue initially during testing because I was working on my development environment, which had far fewer jobs in flight, and moreover I was focused on deployments and replicasets.

## kubernetes_pod_restarting

This rule produced some false positives due to a rarer combination of events. The rule depends on taking increase() on a range vector from kube_pod_container_status_restarts_total. This is a counter metric. Counterintuitively, increase() works by first calculating rate() across a range vector, and then multiplying by the range vector's time interval. Thus, if a label set is only present for a subset of the time interval, the value returned will be a linear extrapolation, and not a simple difference in values. This behavior caused false positives in cases where a container restarted once shortly before it was deleted. This could happen for benign reasons, as all our application deployments restart themselves hourly, and autoscaling can delete pods. The metric kube_pod_container_status_restarts_total would look like a single step up, followed by a cutoff where we have no data. In the fifteen minutes following this event, increase(kube_pod_container_status_restarts_total) would look like a sawtooth wave overlaid on something like 1/x, as the computed rate() appears to get steeper while the window of valid data shrinks. If the time between the restart and pod deletion was short enough, then this would exceed the alerting rule's threshold, and we would get a false positive.

I made two changes to fix this rule. First, I multiplied by the info metric kube_pod_info as an instant vector. This will knock out any label sets for pods that no longer exist, and get rid of the potential 1/x behavior fifteen minutes after a pod is deleted. Second, I added `for: 5m` to the rule definition, to avoid issues from increase() blowing up if a label set is only present on the right side of the interval. If a container starts up, and restarts only once for some benign reason in its first few minutes, then the rule will only be pending and not firing. If the container only restarts once, then increase() will decay back down as more data comes in across a wider time span. In the event that a container is truly stuck in a reboot loop, then increase() will fluctuate around an asymptote at 2.7, and the rule will activate.