### PR TITLE
Bugfixes for empty ingestion batch handling

### DIFF
--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -169,6 +169,12 @@ impl<'a> BatchAggregator<'a> {
                 &self.logger,
             )
             .read(&self.ingestion_transport.transport.batch_signing_public_keys)?;
+
+            if ingestion_packets.is_empty() {
+                warn!(self.logger, "Skipping empty ingestion batch"; event::BATCH_ID => batch_id.to_string());
+                continue;
+            }
+
             let mut peer_validation_batch_reader = BatchReader::new(
                 Batch::new_validation(self.aggregation_name, batch_id, batch_date, !self.is_first),
                 &*self.peer_validation_transport.transport,

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -42,7 +42,7 @@ pub enum IntakeError {
 impl ErrorClassification for IntakeError {
     fn is_retryable(&self) -> bool {
         match self {
-            // Packet decryption errors are the canonical case of errors that'
+            // Packet decryption errors are the canonical case of errors that
             // don't merit retries.
             IntakeError::PacketDecryption(_)
             // Batches with zero bins or zero packets are likewise not going to

--- a/facilitator/src/transport.rs
+++ b/facilitator/src/transport.rs
@@ -64,7 +64,11 @@ pub trait TransportWriter: Write {
     /// Complete an upload operation, flushing any buffered writes and cleaning
     /// up any related resources. Callers must call this method to successfully
     /// finish an upload. If this method is not called, the upload will be
-    /// canceled when the TransportWriter value is dropped.
+    /// canceled when the TransportWriter value is dropped. It is an error to
+    /// call this without first having written some content.
+    ///
+    /// The `TransportWriter` cannot be used after this method is called,
+    /// regardlesss of whether it succeeds.
     fn complete_upload(&mut self) -> Result<(), TransportError>;
 
     /// Cancel an upload operation, cleaning up any related resources. This
@@ -72,6 +76,9 @@ pub trait TransportWriter: Write {
     /// if complete_upload was not called successfully; errors will be logged.
     /// Callers may call this method manually in order to handle the case that
     /// an error occurs.
+    ///
+    /// The `TransportWriter` cannot be used after this method is called,
+    /// regardlesss of whether it succeeds.
     fn cancel_upload(&mut self) -> Result<(), TransportError>;
 }
 


### PR DESCRIPTION
This PR fixes three bugs uncovered by an unusual occurrence seen in production.

We see reports like this about once a week:
```
MX-YUC-APPLE: Files not summed
The following MX-YUC-APPLE files were not summed for some reason:
com.apple.EN.UserRiskParameters (1)
    •    202203270000 - 202203270800
            ISRG: total_ind_cli: 22743, batch UUID len: 1142
            Google: total_ind_cli: 22743, batch UUID len: 1143
```

So this indicates that while both aggregators processed the same number of inputs (`total_ind-cli`), the Google aggregator reported having aggregated over one more batch. This has been observed before when one aggregator can't process a batch because it can't decrypt one or more ingestion packets in the batch, but in this case, Robert hadn't observed any decryption failures. What he did have were other errors indicating failures to upload peer validations to S3, with an error we hadn't encountered before. So what was happening here is:

* ISRG receives an ingestion batch with UUID `7a553f50-8e20-45fc-9459-b109d2a0e9be` containing one packet and processes it successfully, transmitting a peer validation batch containing one proof share to Google.
* Google receives its corresponding ingestion batch and fails to process it (thus no peer validation is transmitted to ISRG).
* At aggregation time, ISRG schedules an aggregation over 1142 batches. `7a553f50-8e20-45fc-9459-b109d2a0e9be` is not included because ISRG doesn't have the necessary peer validation batch.
* On the Google side, they have the ingestion batch and ISRG's peer validation batch for `7a553f50-8e20-45fc-9459-b109d2a0e9be`, so they conclude they're good to go.
* When Google aggregates batch `7a553f50-8e20-45fc-9459-b109d2a0e9be`, it finds that the ingestion batch is empty and so no packets are added to the aggregation, but the batch UUID does get added to the list in the sum part.

We dug a bit and found that the root cause seems to be that Google's ingestion batch for `7a553f50-8e20-45fc-9459-b109d2a0e9be` was empty. The reason the S3 upload fails during Google's intake job fails is because we are trying to do `CompleteMultipartUpload` with an empty list of parts, which is an error in that API.

The three bugs fixed:
- During intake, we should detect empty ingestion batches and fail with a non-retryable error;
- During aggregation, we should detect empty ingestion batches, still ingest all the other batches, but omit the batch UUIDs of the empty batches from sum parts;
- `S3Transport` should not send `CompleteMultipartUpload` to S3 if no parts were uploaded.