### PR TITLE
Skip Dependabot on non-root Terraform modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,19 +22,7 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
-    directory: "/terraform/modules/kubernetes"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/modules/monitoring"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "terraform"
     directory: "/terraform/cluster_bootstrap"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/cluster_bootstrap/modules/gke"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"


### PR DESCRIPTION
From experience, the required provider versions in these modules will be updated along with the root modules which use them.