### PR TITLE
Fix clippy lints

### DIFF
--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -200,7 +200,7 @@ impl<'a> BatchAggregator<'a> {
                         .packet_decryption_keys
                         .iter()
                         .map(|k| Server::new(ingestion_hdr.bins as usize, self.is_first, k.clone()))
-                        .collect::<Result<_, _>>()
+                        .collect::<Result<Vec<_>, _>>()
                         .map_err(AggregationError::PrioSetup)?,
                 );
             }
@@ -312,7 +312,7 @@ impl<'a> BatchAggregator<'a> {
     /// overall aggregation should be aborted).
     fn aggregate_share(
         &mut self,
-        servers: &mut Vec<Server<FieldPriov2>>,
+        servers: &mut [Server<FieldPriov2>],
         invalid_uuids: &mut Vec<Uuid>,
         ingestion_packets: Vec<IngestionDataSharePacket>,
         peer_validation_packets: Vec<ValidationPacket>,

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -568,7 +568,7 @@ impl TryFrom<Value> for IngestionDataSharePacket {
 impl IngestionDataSharePacket {
     pub(crate) fn generate_validation_packet(
         &self,
-        servers: &mut Vec<Server<FieldPriov2>>,
+        servers: &mut [Server<FieldPriov2>],
     ) -> Result<ValidationPacket, IntakeError> {
         let r_pit = FieldPriov2::from(
             u32::try_from(self.r_pit)


### PR DESCRIPTION
The 1.60.0 toolchain brings improvements to [`#[warn(clippy::ptr_arg)]`](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg), for mutable pointers, and this emitted a warning on our codebase in two places.