### PR TITLE
facilitator: command-line help reference tests

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -383,6 +383,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concolor"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015267563b1df20adccdd00cb05257b1dfbea70a04928e9cf88ffb850c1a40af"
+dependencies = [
+ "atty",
+ "bitflags",
+ "concolor-query",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6417fe6fc03a8b533fd2177742eeb39a90c7233eedec7bac96d4d6b69a09449"
+
+[[package]]
 name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +420,15 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "core-foundation"
@@ -454,12 +490,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.3"
+name = "crossbeam-deque"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
  "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
  "cfg-if",
  "lazy_static",
 ]
@@ -586,6 +646,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +668,12 @@ dependencies = [
  "rfc6979",
  "signature",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
@@ -680,6 +752,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "trycmd",
  "ureq",
  "url",
  "urlencoding",
@@ -711,6 +784,18 @@ checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
  "rand_core 0.6.1",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.2.10",
+ "winapi",
 ]
 
 [[package]]
@@ -888,6 +973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "group"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "headers"
@@ -1026,6 +1117,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1109,6 +1216,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1144,6 +1260,15 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "kstring"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1225,6 +1350,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1310,6 +1444,12 @@ dependencies = [
  "tempfile",
  "twoway",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -1403,6 +1543,16 @@ name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "os_pipe"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c92f2b54f081d635c77e7120862d48db8e91f7f21cef23ab1b4fe9971c59f55"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "p256"
@@ -1704,6 +1854,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2024,6 +2199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2346,6 +2530,32 @@ dependencies = [
  "byteorder",
  "lazy_static",
 ]
+
+[[package]]
+name = "snapbox"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f212b806d6f56d19838e36a0aaa7e79a0bc9ca177e873fb87651ad92f983e2"
+dependencies = [
+ "concolor",
+ "content_inspector",
+ "dunce",
+ "filetime",
+ "normalize-line-endings",
+ "os_pipe",
+ "similar",
+ "snapbox-macros",
+ "tempfile",
+ "wait-timeout",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01dea7e04cbb27ef4c86e9922184608185f7cd95c1763bc30d727cda4a5e930"
 
 [[package]]
 name = "socket2"
@@ -2663,6 +2873,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744e9ed5b352340aa47ce033716991b5589e23781acb97cad37d4ea70560f55b"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+ "kstring",
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,6 +2982,22 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "trycmd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c21f68a540a24b162ca101e3f7f4ce3c8458f594f28080018f29da23ad8567b"
+dependencies = [
+ "glob",
+ "humantime",
+ "humantime-serde",
+ "rayon",
+ "serde",
+ "shlex",
+ "snapbox",
+ "toml_edit",
+]
 
 [[package]]
 name = "tungstenite"
@@ -2938,6 +3177,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3099,6 +3358,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,6 +3386,12 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -55,6 +55,7 @@ tokio = { version = "^1.16", features = ["full"] }
 tracing = "0.1.33"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
+trycmd = "0.13.3"
 ureq = { version = "^2.4", features = ["json"] }
 url = "2.2.2"
 urlencoding = "2.1.0"

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -2638,3 +2638,11 @@ fn termination_instant_from_args(
 fn should_terminate(termination_instant: Option<Instant>) -> bool {
     termination_instant.map_or(false, |end| Instant::now() > end)
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn cli_tests() {
+        trycmd::TestCases::new().case("tests/cmd/*.trycmd").run();
+    }
+}

--- a/facilitator/tests/cmd/aggregate-worker.trycmd
+++ b/facilitator/tests/cmd/aggregate-worker.trycmd
@@ -1,0 +1,185 @@
+```
+$ facilitator aggregate-worker --help
+facilitator-aggregate-worker 
+Consume aggregate tasks from a queue.
+
+Storage arguments: Any flag ending in -input or -output can take an S3 bucket (s3://<region>/<bucket>), a Google Storage
+bucket (gs://), or a local directory name. The corresponding -identity flag specifies what identity to use with a
+bucket.
+
+        For S3 buckets: An identity flag may contain an AWS IAM role, specified using an ARN (i.e. "arn:...").
+Facilitator will assume that role using an OIDC auth token obtained from the GKE metadata service. Appropriate mappings
+need to be in place from Facilitator's k8s service account to its GCP service account to the IAM role. If the identity
+flag is omitted or is the empty string, use credentials from ~/.aws.
+
+        For GS buckets: An identity flag may contain a GCP service account (identified by an email address). Requests to
+Google Storage (gs://) are always authenticated as one of our service accounts by GKE's Workload Identity feature:
+https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity. If an identity flag is set, facilitator will
+use its default service account to impersonate a different account, which should have permissions to write to or read
+from the named bucket. If an identity flag is omitted or is the empty string, the default service account exposed by the
+GKE metadata service is used. Keys: All keys are P-256. Public keys are base64-encoded DER SPKI. Private keys are in the
+base64 encoded format expected by libprio-rs, or base64-encoded PKCS#8, as documented. 
+
+USAGE:
+    facilitator aggregate-worker [OPTIONS] --batch-signing-private-key <B64_PKCS8> --batch-signing-private-key-default-identifier <ID> --instance-name <NAME> --is-first <BOOL> --packet-decryption-keys <B64>... --task-queue-kind <task-queue-kind> --task-queue-name <task-queue-name>
+
+FLAGS:
+    -h, --help       
+            Prints help information
+
+    -V, --version    
+            Prints version information
+
+
+OPTIONS:
+        --aws-sqs-region <aws-sqs-region>
+            AWS region in which to use SQS [env: AWS_SQS_REGION=]
+
+        --batch-signing-private-key <B64_PKCS8>
+            Base64 encoded PKCS#8 document containing P-256 batch signing private key to be used by this server when
+            sending messages to other servers. [env: BATCH_SIGNING_PRIVATE_KEY=]
+        --batch-signing-private-key-default-identifier <ID>
+            Identifier for the default batch signing keypair to use, corresponding to an entry in this server's global
+            or specific manifest. Used only if --batch-signing-private-key-identifier is not specified. Used to
+            construct PrioBatchSignature messages. [env: BATCH_SIGNING_PRIVATE_KEY_DEFAULT_IDENTIFIER=]
+        --batch-signing-private-key-identifier <ID>
+            Identifier for the batch signing keypair to use, corresponding to an entry in this server's global or
+            specific manifest. Used to construct PrioBatchSignature messages. [env:
+            BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER=]
+        --gcp-project-id <gcp-project-id>
+            The GCP Project ID in which the PubSub topic implementing the work queue was created. Required if the task
+            queue is a PubSub topic. [env: GCP_PROJECT_ID=]
+        --gcp-service-account-key-file <gcp-service-account-key-file>
+            Path to the JSON key file for the GCP service account that should be used by for accessing GCP or
+            impersonating other GCP service accounts. If omitted, the default account found in the GKE metadata service
+            will be used for authentication or impersonation. [env: GCP_SERVICE_ACCOUNT_KEY_FILE=]
+        --gcp-workload-identity-pool-provider <gcp-workload-identity-pool-provider>
+            Full resource name of a GCP workload identity pool provider that should be used for accessing GCP or
+            impersonating other GCP service accounts when running in Amazon EKS. The pool provider should be configured
+            to permit service account impersonation by the AWS IAM role or user that this facilitator authenticates as.
+            [env: GCP_WORKLOAD_IDENTITY_POOL_PROVIDER=]
+        --ingestor-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If ingestor-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the
+            specified GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            INGESTOR_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --ingestor-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket ingestor. May not be set if ingestor-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            INGESTOR_IDENTITY=]
+        --ingestor-input <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: INGESTOR_INPUT=]
+
+        --ingestor-manifest-base-url <BASE_URL>
+            Base URL from which the ingestor vends manifests, enabling this data share processor to retrieve the global
+            or specific manifest for the server and obtain storage buckets and batch signing public keys. [env:
+            INGESTOR_MANIFEST_BASE_URL=]
+        --ingestor-public-key <B64>
+            Batch signing public key for the ingestor
+
+        --ingestor-public-key-identifier <KEY_ID>
+            Identifier for the ingestor's batch keypair
+
+        --ingestor-use-default-aws-credentials-provider <BOOL>
+            If true and ingestor-identity is unset, the default AWS credentials provider will be used when using S3 APIs
+            for ingestor bucket. If false or unset and ingestor-identity is unset, a web identity provider configured
+            from the Kubernetes environment will be used. If false or unset and ingestor-identity is set, a web identity
+            provider configured from the GKE metadata service is used. May not be set to true if ingestor-identity is
+            set. Should only be set to true if running in AWS. [env: INGESTOR_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]
+            [default: false]  [possible values: true, false]
+        --instance-name <NAME>
+            Name of this data share processor instance, to be used to look up manifests to discover resources owned by
+            this server and peers. e.g., the instance for the state "zc" and ingestor server "megacorp" would be "zc-
+            megacorp". [env: INSTANCE_NAME=]
+        --is-first <BOOL>
+            Whether this is the "first" server receiving a share, i.e., the PHA. [env: IS_FIRST=]  [possible values:
+            true, false]
+        --metrics-scrape-port <metrics-scrape-port>
+            TCP port on which to expose Prometheus /metrics endpoint [env: METRICS_SCRAPE_PORT=]  [default: 8080]
+
+        --packet-decryption-keys <B64>...                                              
+            List of packet decryption private keys, comma separated. When decrypting packets, all provided keys will be
+            tried until one works. [env: PACKET_DECRYPTION_KEYS=]
+        --peer-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If peer-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the specified
+            GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            PEER_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --peer-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket peer. May not be set if peer-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            PEER_IDENTITY=]
+        --peer-input <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: PEER_INPUT=]
+
+        --peer-manifest-base-url <BASE_URL>
+            Base URL from which the peer vends manifests, enabling this data share processor to retrieve the global or
+            specific manifest for the server and obtain storage buckets and batch signing public keys. [env:
+            PEER_MANIFEST_BASE_URL=]
+        --peer-public-key <B64>
+            Batch signing public key for the peer
+
+        --peer-public-key-identifier <KEY_ID>
+            Identifier for the peer's batch keypair
+
+        --peer-use-default-aws-credentials-provider <BOOL>
+            If true and peer-identity is unset, the default AWS credentials provider will be used when using S3 APIs for
+            peer bucket. If false or unset and peer-identity is unset, a web identity provider configured from the
+            Kubernetes environment will be used. If false or unset and peer-identity is set, a web identity provider
+            configured from the GKE metadata service is used. May not be set to true if peer-identity is set. Should
+            only be set to true if running in AWS. [env: PEER_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]
+            [possible values: true, false]
+        --permit-malformed-batch <BOOL>
+            Whether to permit malformed batches. When malformed batches are permitted, facilitator does not abort batch
+            intake or aggregation if an a batch with an invalid signature or an incorrect packet file digest is
+            encountered. If the batch can still be parsed and is otherwise valid, it will be processed. [env:
+            PERMIT_MALFORMED_BATCH=]  [default: false]  [possible values: true, false]
+        --portal-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If portal-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the
+            specified GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            PORTAL_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --portal-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket portal. May not be set if portal-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            PORTAL_IDENTITY=]
+        --portal-manifest-base-url <BASE_URL>
+            Base URL from which the portal vends manifests, enabling this data share processor to retrieve the global or
+            specific manifest for the server and obtain storage buckets and batch signing public keys. [env:
+            PORTAL_MANIFEST_BASE_URL=]
+        --portal-output <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: PORTAL_OUTPUT=]
+
+        --portal-use-default-aws-credentials-provider <BOOL>
+            If true and portal-identity is unset, the default AWS credentials provider will be used when using S3 APIs
+            for portal bucket. If false or unset and portal-identity is unset, a web identity provider configured from
+            the Kubernetes environment will be used. If false or unset and portal-identity is set, a web identity
+            provider configured from the GKE metadata service is used. May not be set to true if portal-identity is set.
+            Should only be set to true if running in AWS. [env: PORTAL_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default:
+            false]  [possible values: true, false]
+        --pubsub-api-endpoint <pubsub-api-endpoint>
+            API endpoint for GCP PubSub. Optional. [env: PUBSUB_API_ENDPOINT=]  [default: https://pubsub.googleapis.com]
+
+        --rejected-topic <rejected-topic>
+            Name of topic associated with the rejected task queue. Tasks that result in non-retryable failures will be
+            forwarded to this topic, and acknowledged and removed from the task queue. If no rejected task topic is,
+            provided, the task will not be acknowledged, and it is expected the queue will eventually move the task to
+            the dead letter queue instead, once it has exhausted its retries. [env: REJECTED_TOPIC=]
+        --task-queue-identity <task-queue-identity>
+            Identity to assume when accessing task queue. Should only be set when running under GKE and task-queue-kind
+            is PubSub. [env: TASK_QUEUE_IDENTITY=]
+        --task-queue-kind <task-queue-kind>
+            kind of task queue to use [env: TASK_QUEUE_KIND=]  [possible values: gcp-pubsub, aws-sqs]
+
+        --task-queue-name <task-queue-name>
+            Name of queue from which tasks should be pulled. On GCP, a PubSub subscription ID. On AWS, an SQS queue URL.
+            [env: TASK_QUEUE_NAME=]
+        --task-queue-use-default-aws-credentials-provider <BOOL>
+            Whether to use the default AWS credentials provider when using SQS APIs. If unset and task-queue-kind is
+            SQS, uses a web identity provider configured from Kubernetes environment. Should not be set unless task-
+            queue-kind is SQS. [env: TASK_QUEUE_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]  [possible
+            values: true, false]
+        --worker-maximum-lifetime <SECONDS>
+            Specifies the maximum lifetime of a worker in seconds. After this amount of time, workers will terminate
+            successfully. Termination may not be immediate: workers may choose to complete their current work item
+            before terminating, but in all cases workers will not start a new work item after their lifetime is
+            complete. [env: WORKER_MAXIMUM_LIFETIME=]
+
+```

--- a/facilitator/tests/cmd/aggregate.trycmd
+++ b/facilitator/tests/cmd/aggregate.trycmd
@@ -1,0 +1,164 @@
+```
+$ facilitator aggregate --help
+facilitator-aggregate 
+Verify peer validation share and emit sum part.
+
+Storage arguments: Any flag ending in -input or -output can take an S3 bucket (s3://<region>/<bucket>), a Google Storage
+bucket (gs://), or a local directory name. The corresponding -identity flag specifies what identity to use with a
+bucket.
+
+        For S3 buckets: An identity flag may contain an AWS IAM role, specified using an ARN (i.e. "arn:...").
+Facilitator will assume that role using an OIDC auth token obtained from the GKE metadata service. Appropriate mappings
+need to be in place from Facilitator's k8s service account to its GCP service account to the IAM role. If the identity
+flag is omitted or is the empty string, use credentials from ~/.aws.
+
+        For GS buckets: An identity flag may contain a GCP service account (identified by an email address). Requests to
+Google Storage (gs://) are always authenticated as one of our service accounts by GKE's Workload Identity feature:
+https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity. If an identity flag is set, facilitator will
+use its default service account to impersonate a different account, which should have permissions to write to or read
+from the named bucket. If an identity flag is omitted or is the empty string, the default service account exposed by the
+GKE metadata service is used. Keys: All keys are P-256. Public keys are base64-encoded DER SPKI. Private keys are in the
+base64 encoded format expected by libprio-rs, or base64-encoded PKCS#8, as documented. 
+
+USAGE:
+    facilitator aggregate [OPTIONS] --aggregation-end <DATE> --aggregation-id <ID> --aggregation-start <DATE> --batch-signing-private-key <B64_PKCS8> --batch-signing-private-key-default-identifier <ID> --instance-name <NAME> --is-first <BOOL> --packet-decryption-keys <B64>...
+
+FLAGS:
+    -h, --help       
+            Prints help information
+
+    -V, --version    
+            Prints version information
+
+
+OPTIONS:
+        --aggregation-end <DATE>
+            End of the timespan covered by the aggregation.
+
+        --aggregation-id <ID>                                                          
+            Name of the aggregation
+
+        --aggregation-start <DATE>
+            Beginning of the timespan covered by the aggregation.
+
+        --batch-id <UUID>...
+            Batch IDs being aggregated. May be specified multiple times. Must be specified in the same order as batch-
+            time values.
+        --batch-signing-private-key <B64_PKCS8>
+            Base64 encoded PKCS#8 document containing P-256 batch signing private key to be used by this server when
+            sending messages to other servers. [env: BATCH_SIGNING_PRIVATE_KEY=]
+        --batch-signing-private-key-default-identifier <ID>
+            Identifier for the default batch signing keypair to use, corresponding to an entry in this server's global
+            or specific manifest. Used only if --batch-signing-private-key-identifier is not specified. Used to
+            construct PrioBatchSignature messages. [env: BATCH_SIGNING_PRIVATE_KEY_DEFAULT_IDENTIFIER=]
+        --batch-signing-private-key-identifier <ID>
+            Identifier for the batch signing keypair to use, corresponding to an entry in this server's global or
+            specific manifest. Used to construct PrioBatchSignature messages. [env:
+            BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER=]
+        --batch-time <DATE>...
+            Date for the batches in YYYY/mm/dd/HH/MM format. Must be specified in the same order as batch-id values.
+
+        --gcp-service-account-key-file <gcp-service-account-key-file>
+            Path to the JSON key file for the GCP service account that should be used by for accessing GCP or
+            impersonating other GCP service accounts. If omitted, the default account found in the GKE metadata service
+            will be used for authentication or impersonation. [env: GCP_SERVICE_ACCOUNT_KEY_FILE=]
+        --gcp-workload-identity-pool-provider <gcp-workload-identity-pool-provider>
+            Full resource name of a GCP workload identity pool provider that should be used for accessing GCP or
+            impersonating other GCP service accounts when running in Amazon EKS. The pool provider should be configured
+            to permit service account impersonation by the AWS IAM role or user that this facilitator authenticates as.
+            [env: GCP_WORKLOAD_IDENTITY_POOL_PROVIDER=]
+        --ingestor-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If ingestor-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the
+            specified GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            INGESTOR_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --ingestor-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket ingestor. May not be set if ingestor-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            INGESTOR_IDENTITY=]
+        --ingestor-input <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: INGESTOR_INPUT=]
+
+        --ingestor-manifest-base-url <BASE_URL>
+            Base URL from which the ingestor vends manifests, enabling this data share processor to retrieve the global
+            or specific manifest for the server and obtain storage buckets and batch signing public keys. [env:
+            INGESTOR_MANIFEST_BASE_URL=]
+        --ingestor-public-key <B64>
+            Batch signing public key for the ingestor
+
+        --ingestor-public-key-identifier <KEY_ID>
+            Identifier for the ingestor's batch keypair
+
+        --ingestor-use-default-aws-credentials-provider <BOOL>
+            If true and ingestor-identity is unset, the default AWS credentials provider will be used when using S3 APIs
+            for ingestor bucket. If false or unset and ingestor-identity is unset, a web identity provider configured
+            from the Kubernetes environment will be used. If false or unset and ingestor-identity is set, a web identity
+            provider configured from the GKE metadata service is used. May not be set to true if ingestor-identity is
+            set. Should only be set to true if running in AWS. [env: INGESTOR_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]
+            [default: false]  [possible values: true, false]
+        --instance-name <NAME>
+            Name of this data share processor instance, to be used to look up manifests to discover resources owned by
+            this server and peers. e.g., the instance for the state "zc" and ingestor server "megacorp" would be "zc-
+            megacorp". [env: INSTANCE_NAME=]
+        --is-first <BOOL>
+            Whether this is the "first" server receiving a share, i.e., the PHA. [env: IS_FIRST=]  [possible values:
+            true, false]
+        --packet-decryption-keys <B64>...                                              
+            List of packet decryption private keys, comma separated. When decrypting packets, all provided keys will be
+            tried until one works. [env: PACKET_DECRYPTION_KEYS=]
+        --peer-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If peer-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the specified
+            GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            PEER_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --peer-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket peer. May not be set if peer-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            PEER_IDENTITY=]
+        --peer-input <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: PEER_INPUT=]
+
+        --peer-manifest-base-url <BASE_URL>
+            Base URL from which the peer vends manifests, enabling this data share processor to retrieve the global or
+            specific manifest for the server and obtain storage buckets and batch signing public keys. [env:
+            PEER_MANIFEST_BASE_URL=]
+        --peer-public-key <B64>
+            Batch signing public key for the peer
+
+        --peer-public-key-identifier <KEY_ID>
+            Identifier for the peer's batch keypair
+
+        --peer-use-default-aws-credentials-provider <BOOL>
+            If true and peer-identity is unset, the default AWS credentials provider will be used when using S3 APIs for
+            peer bucket. If false or unset and peer-identity is unset, a web identity provider configured from the
+            Kubernetes environment will be used. If false or unset and peer-identity is set, a web identity provider
+            configured from the GKE metadata service is used. May not be set to true if peer-identity is set. Should
+            only be set to true if running in AWS. [env: PEER_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]
+            [possible values: true, false]
+        --permit-malformed-batch <BOOL>
+            Whether to permit malformed batches. When malformed batches are permitted, facilitator does not abort batch
+            intake or aggregation if an a batch with an invalid signature or an incorrect packet file digest is
+            encountered. If the batch can still be parsed and is otherwise valid, it will be processed. [env:
+            PERMIT_MALFORMED_BATCH=]  [default: false]  [possible values: true, false]
+        --portal-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If portal-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the
+            specified GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            PORTAL_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --portal-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket portal. May not be set if portal-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            PORTAL_IDENTITY=]
+        --portal-manifest-base-url <BASE_URL>
+            Base URL from which the portal vends manifests, enabling this data share processor to retrieve the global or
+            specific manifest for the server and obtain storage buckets and batch signing public keys. [env:
+            PORTAL_MANIFEST_BASE_URL=]
+        --portal-output <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: PORTAL_OUTPUT=]
+
+        --portal-use-default-aws-credentials-provider <BOOL>
+            If true and portal-identity is unset, the default AWS credentials provider will be used when using S3 APIs
+            for portal bucket. If false or unset and portal-identity is unset, a web identity provider configured from
+            the Kubernetes environment will be used. If false or unset and portal-identity is set, a web identity
+            provider configured from the GKE metadata service is used. May not be set to true if portal-identity is set.
+            Should only be set to true if running in AWS. [env: PORTAL_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default:
+            false]  [possible values: true, false]
+
+```

--- a/facilitator/tests/cmd/generate-ingestion-sample-worker.trycmd
+++ b/facilitator/tests/cmd/generate-ingestion-sample-worker.trycmd
@@ -1,0 +1,123 @@
+```
+$ facilitator generate-ingestion-sample-worker --help
+facilitator-generate-ingestion-sample-worker 
+Spawn a worker to generate sample data files
+
+USAGE:
+    facilitator generate-ingestion-sample-worker [OPTIONS] --aggregation-id <ID> --batch-end-time <MILLIS> --batch-start-time <MILLIS> --dimension <INT> --epsilon <DOUBLE> --generation-interval <INTERVAL> --packet-count <INT> <--facilitator-ecies-public-key <B64>|--facilitator-manifest-base-url <URL>> <--ingestor-manifest-base-url <URL>|--batch-signing-private-key <B64_PKCS8>> <--pha-ecies-public-key <B64>|--pha-manifest-base-url <URL>>
+
+FLAGS:
+    -h, --help       
+            Prints help information
+
+    -V, --version    
+            Prints version information
+
+
+OPTIONS:
+        --aggregation-id <ID>                                                         
+            Name of the aggregation
+
+        --batch-end-time <MILLIS>
+            End of timespan covered by the batch, in milliseconds since epoch
+
+        --batch-id <UUID>
+            UUID of the batch. If omitted, a UUID is randomly generated.
+
+        --batch-signing-private-key <B64_PKCS8>
+            Base64 encoded PKCS#8 document containing P-256 batch signing private key to be used by this server when
+            sending messages to other servers. [env: BATCH_SIGNING_PRIVATE_KEY=]
+        --batch-signing-private-key-default-identifier <ID>
+            Identifier for the default batch signing keypair to use, corresponding to an entry in this server's global
+            or specific manifest. Used only if --batch-signing-private-key-identifier is not specified. Used to
+            construct PrioBatchSignature messages. [env: BATCH_SIGNING_PRIVATE_KEY_DEFAULT_IDENTIFIER=]
+        --batch-signing-private-key-identifier <ID>
+            Identifier for the batch signing keypair to use, corresponding to an entry in this server's global or
+            specific manifest. Used to construct PrioBatchSignature messages. [env:
+            BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER=]
+        --batch-start-time <MILLIS>
+            Start of timespan covered by the batch, in milliseconds since epoch
+
+        --date <DATE>
+            Date for the batch in YYYY/mm/dd/HH/MM format. If omitted, the current date is used.
+
+    -d, --dimension <INT>
+            Length in bits of the data packets to generate (a.k.a. "bins" in some contexts). Must be a natural number.
+
+        --epsilon <DOUBLE>
+            Differential privacy parameter for local randomization before aggregation
+
+        --facilitator-ecies-public-key <B64>
+            Base64 encoded X9.62 uncompressed public key for the facilitator server [env: FACILITATOR_ECIES_PUBLIC_KEY=]
+
+        --facilitator-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If facilitator-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the
+            specified GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            FACILITATOR_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --facilitator-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket facilitator. May not be set if facilitator-use-
+            default-aws-credentials-provider is true. Should only be set when running in GKE. [env:
+            FACILITATOR_IDENTITY=]
+        --facilitator-manifest-base-url <URL>
+            Base URL of the Facilitator manifest [env: FACILITATOR_MANIFEST_BASE_URL=]
+
+        --facilitator-output <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: FACILITATOR_OUTPUT=]
+
+        --facilitator-use-default-aws-credentials-provider <BOOL>
+            If true and facilitator-identity is unset, the default AWS credentials provider will be used when using S3
+            APIs for facilitator bucket. If false or unset and facilitator-identity is unset, a web identity provider
+            configured from the Kubernetes environment will be used. If false or unset and facilitator-identity is set,
+            a web identity provider configured from the GKE metadata service is used. May not be set to true if
+            facilitator-identity is set. Should only be set to true if running in AWS. [env:
+            FACILITATOR_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]  [possible values: true, false]
+        --gcp-service-account-key-file <gcp-service-account-key-file>
+            Path to the JSON key file for the GCP service account that should be used by for accessing GCP or
+            impersonating other GCP service accounts. If omitted, the default account found in the GKE metadata service
+            will be used for authentication or impersonation. [env: GCP_SERVICE_ACCOUNT_KEY_FILE=]
+        --generation-interval <INTERVAL>
+            How often should samples be generated in seconds
+
+        --ingestor-manifest-base-url <URL>
+            Base URL of this ingestor's manifest [env: INGESTOR_MANIFEST_BASE_URL=]
+
+        --ingestor-name <STRING>                                                      
+            Name of this ingestor
+
+        --locality-name <STRING>
+            Name of the locality this ingestor is targeting
+
+    -p, --packet-count <INT>                                                          
+            Number of data packets to generate
+
+        --peer-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If peer-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the specified
+            GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            PEER_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --peer-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket peer. May not be set if peer-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            PEER_IDENTITY=]
+        --peer-output <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: PEER_OUTPUT=]
+
+        --peer-use-default-aws-credentials-provider <BOOL>
+            If true and peer-identity is unset, the default AWS credentials provider will be used when using S3 APIs for
+            peer bucket. If false or unset and peer-identity is unset, a web identity provider configured from the
+            Kubernetes environment will be used. If false or unset and peer-identity is set, a web identity provider
+            configured from the GKE metadata service is used. May not be set to true if peer-identity is set. Should
+            only be set to true if running in AWS. [env: PEER_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]
+            [possible values: true, false]
+        --pha-ecies-public-key <B64>
+            Base64 encoded X9.62 uncompressed public key for the PHA server [env: PHA_ECIES_PUBLIC_KEY=]
+
+        --pha-manifest-base-url <URL>
+            Base URL of the Public Health Authority manifest [env: PHA_MANIFEST_BASE_URL=]
+
+        --worker-maximum-lifetime <SECONDS>
+            Specifies the maximum lifetime of a worker in seconds. After this amount of time, workers will terminate
+            successfully. Termination may not be immediate: workers may choose to complete their current work item
+            before terminating, but in all cases workers will not start a new work item after their lifetime is
+            complete. [env: WORKER_MAXIMUM_LIFETIME=]
+
+```

--- a/facilitator/tests/cmd/generate-ingestion-sample.trycmd
+++ b/facilitator/tests/cmd/generate-ingestion-sample.trycmd
@@ -1,0 +1,123 @@
+```
+$ facilitator generate-ingestion-sample-worker --help
+facilitator-generate-ingestion-sample-worker 
+Spawn a worker to generate sample data files
+
+USAGE:
+    facilitator generate-ingestion-sample-worker [OPTIONS] --aggregation-id <ID> --batch-end-time <MILLIS> --batch-start-time <MILLIS> --dimension <INT> --epsilon <DOUBLE> --generation-interval <INTERVAL> --packet-count <INT> <--facilitator-ecies-public-key <B64>|--facilitator-manifest-base-url <URL>> <--ingestor-manifest-base-url <URL>|--batch-signing-private-key <B64_PKCS8>> <--pha-ecies-public-key <B64>|--pha-manifest-base-url <URL>>
+
+FLAGS:
+    -h, --help       
+            Prints help information
+
+    -V, --version    
+            Prints version information
+
+
+OPTIONS:
+        --aggregation-id <ID>                                                         
+            Name of the aggregation
+
+        --batch-end-time <MILLIS>
+            End of timespan covered by the batch, in milliseconds since epoch
+
+        --batch-id <UUID>
+            UUID of the batch. If omitted, a UUID is randomly generated.
+
+        --batch-signing-private-key <B64_PKCS8>
+            Base64 encoded PKCS#8 document containing P-256 batch signing private key to be used by this server when
+            sending messages to other servers. [env: BATCH_SIGNING_PRIVATE_KEY=]
+        --batch-signing-private-key-default-identifier <ID>
+            Identifier for the default batch signing keypair to use, corresponding to an entry in this server's global
+            or specific manifest. Used only if --batch-signing-private-key-identifier is not specified. Used to
+            construct PrioBatchSignature messages. [env: BATCH_SIGNING_PRIVATE_KEY_DEFAULT_IDENTIFIER=]
+        --batch-signing-private-key-identifier <ID>
+            Identifier for the batch signing keypair to use, corresponding to an entry in this server's global or
+            specific manifest. Used to construct PrioBatchSignature messages. [env:
+            BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER=]
+        --batch-start-time <MILLIS>
+            Start of timespan covered by the batch, in milliseconds since epoch
+
+        --date <DATE>
+            Date for the batch in YYYY/mm/dd/HH/MM format. If omitted, the current date is used.
+
+    -d, --dimension <INT>
+            Length in bits of the data packets to generate (a.k.a. "bins" in some contexts). Must be a natural number.
+
+        --epsilon <DOUBLE>
+            Differential privacy parameter for local randomization before aggregation
+
+        --facilitator-ecies-public-key <B64>
+            Base64 encoded X9.62 uncompressed public key for the facilitator server [env: FACILITATOR_ECIES_PUBLIC_KEY=]
+
+        --facilitator-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If facilitator-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the
+            specified GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            FACILITATOR_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --facilitator-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket facilitator. May not be set if facilitator-use-
+            default-aws-credentials-provider is true. Should only be set when running in GKE. [env:
+            FACILITATOR_IDENTITY=]
+        --facilitator-manifest-base-url <URL>
+            Base URL of the Facilitator manifest [env: FACILITATOR_MANIFEST_BASE_URL=]
+
+        --facilitator-output <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: FACILITATOR_OUTPUT=]
+
+        --facilitator-use-default-aws-credentials-provider <BOOL>
+            If true and facilitator-identity is unset, the default AWS credentials provider will be used when using S3
+            APIs for facilitator bucket. If false or unset and facilitator-identity is unset, a web identity provider
+            configured from the Kubernetes environment will be used. If false or unset and facilitator-identity is set,
+            a web identity provider configured from the GKE metadata service is used. May not be set to true if
+            facilitator-identity is set. Should only be set to true if running in AWS. [env:
+            FACILITATOR_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]  [possible values: true, false]
+        --gcp-service-account-key-file <gcp-service-account-key-file>
+            Path to the JSON key file for the GCP service account that should be used by for accessing GCP or
+            impersonating other GCP service accounts. If omitted, the default account found in the GKE metadata service
+            will be used for authentication or impersonation. [env: GCP_SERVICE_ACCOUNT_KEY_FILE=]
+        --generation-interval <INTERVAL>
+            How often should samples be generated in seconds
+
+        --ingestor-manifest-base-url <URL>
+            Base URL of this ingestor's manifest [env: INGESTOR_MANIFEST_BASE_URL=]
+
+        --ingestor-name <STRING>                                                      
+            Name of this ingestor
+
+        --locality-name <STRING>
+            Name of the locality this ingestor is targeting
+
+    -p, --packet-count <INT>                                                          
+            Number of data packets to generate
+
+        --peer-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If peer-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the specified
+            GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            PEER_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --peer-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket peer. May not be set if peer-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            PEER_IDENTITY=]
+        --peer-output <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: PEER_OUTPUT=]
+
+        --peer-use-default-aws-credentials-provider <BOOL>
+            If true and peer-identity is unset, the default AWS credentials provider will be used when using S3 APIs for
+            peer bucket. If false or unset and peer-identity is unset, a web identity provider configured from the
+            Kubernetes environment will be used. If false or unset and peer-identity is set, a web identity provider
+            configured from the GKE metadata service is used. May not be set to true if peer-identity is set. Should
+            only be set to true if running in AWS. [env: PEER_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]
+            [possible values: true, false]
+        --pha-ecies-public-key <B64>
+            Base64 encoded X9.62 uncompressed public key for the PHA server [env: PHA_ECIES_PUBLIC_KEY=]
+
+        --pha-manifest-base-url <URL>
+            Base URL of the Public Health Authority manifest [env: PHA_MANIFEST_BASE_URL=]
+
+        --worker-maximum-lifetime <SECONDS>
+            Specifies the maximum lifetime of a worker in seconds. After this amount of time, workers will terminate
+            successfully. Termination may not be immediate: workers may choose to complete their current work item
+            before terminating, but in all cases workers will not start a new work item after their lifetime is
+            complete. [env: WORKER_MAXIMUM_LIFETIME=]
+
+```

--- a/facilitator/tests/cmd/intake-batch-worker.trycmd
+++ b/facilitator/tests/cmd/intake-batch-worker.trycmd
@@ -1,0 +1,163 @@
+```
+$ facilitator intake-batch-worker --help
+facilitator-intake-batch-worker 
+Consume intake batch tasks from a queue, validating an input share (from an ingestor's bucket) and emit a validation
+share.
+
+Storage arguments: Any flag ending in -input or -output can take an S3 bucket (s3://<region>/<bucket>), a Google Storage
+bucket (gs://), or a local directory name. The corresponding -identity flag specifies what identity to use with a
+bucket.
+
+        For S3 buckets: An identity flag may contain an AWS IAM role, specified using an ARN (i.e. "arn:...").
+Facilitator will assume that role using an OIDC auth token obtained from the GKE metadata service. Appropriate mappings
+need to be in place from Facilitator's k8s service account to its GCP service account to the IAM role. If the identity
+flag is omitted or is the empty string, use credentials from ~/.aws.
+
+        For GS buckets: An identity flag may contain a GCP service account (identified by an email address). Requests to
+Google Storage (gs://) are always authenticated as one of our service accounts by GKE's Workload Identity feature:
+https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity. If an identity flag is set, facilitator will
+use its default service account to impersonate a different account, which should have permissions to write to or read
+from the named bucket. If an identity flag is omitted or is the empty string, the default service account exposed by the
+GKE metadata service is used. Keys: All keys are P-256. Public keys are base64-encoded DER SPKI. Private keys are in the
+base64 encoded format expected by libprio-rs, or base64-encoded PKCS#8, as documented. 
+
+USAGE:
+    facilitator intake-batch-worker [OPTIONS] --batch-signing-private-key <B64_PKCS8> --batch-signing-private-key-default-identifier <ID> --instance-name <NAME> --is-first <BOOL> --packet-decryption-keys <B64>... --task-queue-kind <task-queue-kind> --task-queue-name <task-queue-name>
+
+FLAGS:
+    -h, --help       
+            Prints help information
+
+    -V, --version    
+            Prints version information
+
+
+OPTIONS:
+        --aws-sqs-region <aws-sqs-region>
+            AWS region in which to use SQS [env: AWS_SQS_REGION=]
+
+        --batch-signing-private-key <B64_PKCS8>
+            Base64 encoded PKCS#8 document containing P-256 batch signing private key to be used by this server when
+            sending messages to other servers. [env: BATCH_SIGNING_PRIVATE_KEY=]
+        --batch-signing-private-key-default-identifier <ID>
+            Identifier for the default batch signing keypair to use, corresponding to an entry in this server's global
+            or specific manifest. Used only if --batch-signing-private-key-identifier is not specified. Used to
+            construct PrioBatchSignature messages. [env: BATCH_SIGNING_PRIVATE_KEY_DEFAULT_IDENTIFIER=]
+        --batch-signing-private-key-identifier <ID>
+            Identifier for the batch signing keypair to use, corresponding to an entry in this server's global or
+            specific manifest. Used to construct PrioBatchSignature messages. [env:
+            BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER=]
+        --gcp-project-id <gcp-project-id>
+            The GCP Project ID in which the PubSub topic implementing the work queue was created. Required if the task
+            queue is a PubSub topic. [env: GCP_PROJECT_ID=]
+        --gcp-service-account-key-file <gcp-service-account-key-file>
+            Path to the JSON key file for the GCP service account that should be used by for accessing GCP or
+            impersonating other GCP service accounts. If omitted, the default account found in the GKE metadata service
+            will be used for authentication or impersonation. [env: GCP_SERVICE_ACCOUNT_KEY_FILE=]
+        --gcp-workload-identity-pool-provider <gcp-workload-identity-pool-provider>
+            Full resource name of a GCP workload identity pool provider that should be used for accessing GCP or
+            impersonating other GCP service accounts when running in Amazon EKS. The pool provider should be configured
+            to permit service account impersonation by the AWS IAM role or user that this facilitator authenticates as.
+            [env: GCP_WORKLOAD_IDENTITY_POOL_PROVIDER=]
+        --ingestor-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If ingestor-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the
+            specified GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            INGESTOR_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --ingestor-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket ingestor. May not be set if ingestor-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            INGESTOR_IDENTITY=]
+        --ingestor-input <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: INGESTOR_INPUT=]
+
+        --ingestor-manifest-base-url <BASE_URL>
+            Base URL from which the ingestor vends manifests, enabling this data share processor to retrieve the global
+            or specific manifest for the server and obtain storage buckets and batch signing public keys. [env:
+            INGESTOR_MANIFEST_BASE_URL=]
+        --ingestor-public-key <B64>
+            Batch signing public key for the ingestor
+
+        --ingestor-public-key-identifier <KEY_ID>
+            Identifier for the ingestor's batch keypair
+
+        --ingestor-use-default-aws-credentials-provider <BOOL>
+            If true and ingestor-identity is unset, the default AWS credentials provider will be used when using S3 APIs
+            for ingestor bucket. If false or unset and ingestor-identity is unset, a web identity provider configured
+            from the Kubernetes environment will be used. If false or unset and ingestor-identity is set, a web identity
+            provider configured from the GKE metadata service is used. May not be set to true if ingestor-identity is
+            set. Should only be set to true if running in AWS. [env: INGESTOR_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]
+            [default: false]  [possible values: true, false]
+        --instance-name <NAME>
+            Name of this data share processor instance, to be used to look up manifests to discover resources owned by
+            this server and peers. e.g., the instance for the state "zc" and ingestor server "megacorp" would be "zc-
+            megacorp". [env: INSTANCE_NAME=]
+        --is-first <BOOL>
+            Whether this is the "first" server receiving a share, i.e., the PHA. [env: IS_FIRST=]  [possible values:
+            true, false]
+        --metrics-scrape-port <metrics-scrape-port>
+            TCP port on which to expose Prometheus /metrics endpoint [env: METRICS_SCRAPE_PORT=]  [default: 8080]
+
+        --packet-decryption-keys <B64>...                                              
+            List of packet decryption private keys, comma separated. When decrypting packets, all provided keys will be
+            tried until one works. [env: PACKET_DECRYPTION_KEYS=]
+        --peer-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If peer-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the specified
+            GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            PEER_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --peer-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket peer. May not be set if peer-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            PEER_IDENTITY=]
+        --peer-manifest-base-url <BASE_URL>
+            Base URL from which the peer vends manifests, enabling this data share processor to retrieve the global or
+            specific manifest for the server and obtain storage buckets and batch signing public keys. [env:
+            PEER_MANIFEST_BASE_URL=]
+        --peer-output <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: PEER_OUTPUT=]
+
+        --peer-use-default-aws-credentials-provider <BOOL>
+            If true and peer-identity is unset, the default AWS credentials provider will be used when using S3 APIs for
+            peer bucket. If false or unset and peer-identity is unset, a web identity provider configured from the
+            Kubernetes environment will be used. If false or unset and peer-identity is set, a web identity provider
+            configured from the GKE metadata service is used. May not be set to true if peer-identity is set. Should
+            only be set to true if running in AWS. [env: PEER_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]
+            [possible values: true, false]
+        --permit-malformed-batch <BOOL>
+            Whether to permit malformed batches. When malformed batches are permitted, facilitator does not abort batch
+            intake or aggregation if an a batch with an invalid signature or an incorrect packet file digest is
+            encountered. If the batch can still be parsed and is otherwise valid, it will be processed. [env:
+            PERMIT_MALFORMED_BATCH=]  [default: false]  [possible values: true, false]
+        --pubsub-api-endpoint <pubsub-api-endpoint>
+            API endpoint for GCP PubSub. Optional. [env: PUBSUB_API_ENDPOINT=]  [default: https://pubsub.googleapis.com]
+
+        --rejected-topic <rejected-topic>
+            Name of topic associated with the rejected task queue. Tasks that result in non-retryable failures will be
+            forwarded to this topic, and acknowledged and removed from the task queue. If no rejected task topic is,
+            provided, the task will not be acknowledged, and it is expected the queue will eventually move the task to
+            the dead letter queue instead, once it has exhausted its retries. [env: REJECTED_TOPIC=]
+        --task-queue-identity <task-queue-identity>
+            Identity to assume when accessing task queue. Should only be set when running under GKE and task-queue-kind
+            is PubSub. [env: TASK_QUEUE_IDENTITY=]
+        --task-queue-kind <task-queue-kind>
+            kind of task queue to use [env: TASK_QUEUE_KIND=]  [possible values: gcp-pubsub, aws-sqs]
+
+        --task-queue-name <task-queue-name>
+            Name of queue from which tasks should be pulled. On GCP, a PubSub subscription ID. On AWS, an SQS queue URL.
+            [env: TASK_QUEUE_NAME=]
+        --task-queue-use-default-aws-credentials-provider <BOOL>
+            Whether to use the default AWS credentials provider when using SQS APIs. If unset and task-queue-kind is
+            SQS, uses a web identity provider configured from Kubernetes environment. Should not be set unless task-
+            queue-kind is SQS. [env: TASK_QUEUE_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]  [possible
+            values: true, false]
+        --worker-maximum-lifetime <SECONDS>
+            Specifies the maximum lifetime of a worker in seconds. After this amount of time, workers will terminate
+            successfully. Termination may not be immediate: workers may choose to complete their current work item
+            before terminating, but in all cases workers will not start a new work item after their lifetime is
+            complete. [env: WORKER_MAXIMUM_LIFETIME=]
+        --write-single-object-validation-batches <BOOL>
+            If set, validation batches will be written in a single-object format. (This makes writing a batch an atomic
+            operation.) If not set, validation batches will be written using the same three-object format used for
+            ingestion & sum part batches. [env: WRITE_SINGLE_OBJECT_VALIDATION_BATCHES=]  [default: false]  [possible
+            values: true, false]
+
+```

--- a/facilitator/tests/cmd/intake-batch.trycmd
+++ b/facilitator/tests/cmd/intake-batch.trycmd
@@ -1,0 +1,135 @@
+```
+$ facilitator intake-batch --help
+facilitator-intake-batch 
+Validate an input share (from an ingestor's bucket) and emit a validation share.
+
+Storage arguments: Any flag ending in -input or -output can take an S3 bucket (s3://<region>/<bucket>), a Google Storage
+bucket (gs://), or a local directory name. The corresponding -identity flag specifies what identity to use with a
+bucket.
+
+        For S3 buckets: An identity flag may contain an AWS IAM role, specified using an ARN (i.e. "arn:...").
+Facilitator will assume that role using an OIDC auth token obtained from the GKE metadata service. Appropriate mappings
+need to be in place from Facilitator's k8s service account to its GCP service account to the IAM role. If the identity
+flag is omitted or is the empty string, use credentials from ~/.aws.
+
+        For GS buckets: An identity flag may contain a GCP service account (identified by an email address). Requests to
+Google Storage (gs://) are always authenticated as one of our service accounts by GKE's Workload Identity feature:
+https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity. If an identity flag is set, facilitator will
+use its default service account to impersonate a different account, which should have permissions to write to or read
+from the named bucket. If an identity flag is omitted or is the empty string, the default service account exposed by the
+GKE metadata service is used. Keys: All keys are P-256. Public keys are base64-encoded DER SPKI. Private keys are in the
+base64 encoded format expected by libprio-rs, or base64-encoded PKCS#8, as documented. 
+
+USAGE:
+    facilitator intake-batch [OPTIONS] --aggregation-id <ID> --batch-id <UUID> --batch-signing-private-key <B64_PKCS8> --batch-signing-private-key-default-identifier <ID> --date <DATE> --instance-name <NAME> --is-first <BOOL> --packet-decryption-keys <B64>...
+
+FLAGS:
+    -h, --help       
+            Prints help information
+
+    -V, --version    
+            Prints version information
+
+
+OPTIONS:
+        --aggregation-id <ID>                                                          
+            Name of the aggregation
+
+        --batch-id <UUID>                                                              
+            UUID of the batch.
+
+        --batch-signing-private-key <B64_PKCS8>
+            Base64 encoded PKCS#8 document containing P-256 batch signing private key to be used by this server when
+            sending messages to other servers. [env: BATCH_SIGNING_PRIVATE_KEY=]
+        --batch-signing-private-key-default-identifier <ID>
+            Identifier for the default batch signing keypair to use, corresponding to an entry in this server's global
+            or specific manifest. Used only if --batch-signing-private-key-identifier is not specified. Used to
+            construct PrioBatchSignature messages. [env: BATCH_SIGNING_PRIVATE_KEY_DEFAULT_IDENTIFIER=]
+        --batch-signing-private-key-identifier <ID>
+            Identifier for the batch signing keypair to use, corresponding to an entry in this server's global or
+            specific manifest. Used to construct PrioBatchSignature messages. [env:
+            BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER=]
+        --date <DATE>
+            Date for the batch in YYYY/mm/dd/HH/MM format
+
+        --gcp-service-account-key-file <gcp-service-account-key-file>
+            Path to the JSON key file for the GCP service account that should be used by for accessing GCP or
+            impersonating other GCP service accounts. If omitted, the default account found in the GKE metadata service
+            will be used for authentication or impersonation. [env: GCP_SERVICE_ACCOUNT_KEY_FILE=]
+        --gcp-workload-identity-pool-provider <gcp-workload-identity-pool-provider>
+            Full resource name of a GCP workload identity pool provider that should be used for accessing GCP or
+            impersonating other GCP service accounts when running in Amazon EKS. The pool provider should be configured
+            to permit service account impersonation by the AWS IAM role or user that this facilitator authenticates as.
+            [env: GCP_WORKLOAD_IDENTITY_POOL_PROVIDER=]
+        --ingestor-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If ingestor-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the
+            specified GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            INGESTOR_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --ingestor-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket ingestor. May not be set if ingestor-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            INGESTOR_IDENTITY=]
+        --ingestor-input <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: INGESTOR_INPUT=]
+
+        --ingestor-manifest-base-url <BASE_URL>
+            Base URL from which the ingestor vends manifests, enabling this data share processor to retrieve the global
+            or specific manifest for the server and obtain storage buckets and batch signing public keys. [env:
+            INGESTOR_MANIFEST_BASE_URL=]
+        --ingestor-public-key <B64>
+            Batch signing public key for the ingestor
+
+        --ingestor-public-key-identifier <KEY_ID>
+            Identifier for the ingestor's batch keypair
+
+        --ingestor-use-default-aws-credentials-provider <BOOL>
+            If true and ingestor-identity is unset, the default AWS credentials provider will be used when using S3 APIs
+            for ingestor bucket. If false or unset and ingestor-identity is unset, a web identity provider configured
+            from the Kubernetes environment will be used. If false or unset and ingestor-identity is set, a web identity
+            provider configured from the GKE metadata service is used. May not be set to true if ingestor-identity is
+            set. Should only be set to true if running in AWS. [env: INGESTOR_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]
+            [default: false]  [possible values: true, false]
+        --instance-name <NAME>
+            Name of this data share processor instance, to be used to look up manifests to discover resources owned by
+            this server and peers. e.g., the instance for the state "zc" and ingestor server "megacorp" would be "zc-
+            megacorp". [env: INSTANCE_NAME=]
+        --is-first <BOOL>
+            Whether this is the "first" server receiving a share, i.e., the PHA. [env: IS_FIRST=]  [possible values:
+            true, false]
+        --packet-decryption-keys <B64>...                                              
+            List of packet decryption private keys, comma separated. When decrypting packets, all provided keys will be
+            tried until one works. [env: PACKET_DECRYPTION_KEYS=]
+        --peer-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If peer-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the specified
+            GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            PEER_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --peer-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket peer. May not be set if peer-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            PEER_IDENTITY=]
+        --peer-manifest-base-url <BASE_URL>
+            Base URL from which the peer vends manifests, enabling this data share processor to retrieve the global or
+            specific manifest for the server and obtain storage buckets and batch signing public keys. [env:
+            PEER_MANIFEST_BASE_URL=]
+        --peer-output <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: PEER_OUTPUT=]
+
+        --peer-use-default-aws-credentials-provider <BOOL>
+            If true and peer-identity is unset, the default AWS credentials provider will be used when using S3 APIs for
+            peer bucket. If false or unset and peer-identity is unset, a web identity provider configured from the
+            Kubernetes environment will be used. If false or unset and peer-identity is set, a web identity provider
+            configured from the GKE metadata service is used. May not be set to true if peer-identity is set. Should
+            only be set to true if running in AWS. [env: PEER_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]
+            [possible values: true, false]
+        --permit-malformed-batch <BOOL>
+            Whether to permit malformed batches. When malformed batches are permitted, facilitator does not abort batch
+            intake or aggregation if an a batch with an invalid signature or an incorrect packet file digest is
+            encountered. If the batch can still be parsed and is otherwise valid, it will be processed. [env:
+            PERMIT_MALFORMED_BATCH=]  [default: false]  [possible values: true, false]
+        --write-single-object-validation-batches <BOOL>
+            If set, validation batches will be written in a single-object format. (This makes writing a batch an atomic
+            operation.) If not set, validation batches will be written using the same three-object format used for
+            ingestion & sum part batches. [env: WRITE_SINGLE_OBJECT_VALIDATION_BATCHES=]  [default: false]  [possible
+            values: true, false]
+
+```

--- a/facilitator/tests/cmd/lint-manifest.trycmd
+++ b/facilitator/tests/cmd/lint-manifest.trycmd
@@ -1,0 +1,32 @@
+```
+$ facilitator lint-manifest --help
+facilitator-lint-manifest 
+Validate and print out global or specific manifests
+
+USAGE:
+    facilitator lint-manifest [OPTIONS] --manifest-base-url <URL> --manifest-kind <KIND> --manifest-path <PATH>
+
+FLAGS:
+    -h, --help       
+            Prints help information
+
+    -V, --version    
+            Prints version information
+
+
+OPTIONS:
+        --instance <INSTANCE_NAME>    
+            the instance name whose manifest is to be fetched, e.g., "mi-google" for a data share processor specific
+            manifest or "mi" for an ingestor specific manifest. Required if manifest-kind=data-share-processor-specific
+            or ingestor-specific.
+        --manifest-base-url <URL>     
+            base URL relative to which manifests may be fetched over HTTPS. Should be in the form "https://foo.com".
+
+        --manifest-kind <KIND>        
+            kind of manifest to locate and parse [possible values: ingestor-global, ingestor-specific, data-share-
+            processor-global, data-share-processor-specific, portal-global]
+        --manifest-path <PATH>        
+            path to local manifest file to lint
+
+
+```

--- a/facilitator/tests/cmd/main.trycmd
+++ b/facilitator/tests/cmd/main.trycmd
@@ -1,0 +1,130 @@
+```
+$ facilitator --help
+facilitator 
+Prio data share processor
+
+USAGE:
+    facilitator [OPTIONS] [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+        --force-json-log-output <BOOL>    Force log output to JSON format [env: FORCE_JSON_LOG_OUTPUT=]  [default:
+                                          false]  [possible values: true, false]
+
+SUBCOMMANDS:
+    aggregate                           Verify peer validation share and emit sum part.
+                                        
+                                        Storage arguments: Any flag ending in -input or -output can take an S3
+                                        bucket (s3://<region>/<bucket>), a Google Storage bucket (gs://), or a local
+                                        directory name. The corresponding -identity flag specifies what identity to
+                                        use with a bucket.
+                                        
+                                                For S3 buckets: An identity flag may contain an AWS IAM role,
+                                        specified using an ARN (i.e. "arn:..."). Facilitator will assume that role
+                                        using an OIDC auth token obtained from the GKE metadata service. Appropriate
+                                        mappings need to be in place from Facilitator's k8s service account to its
+                                        GCP service account to the IAM role. If the identity flag is omitted or is
+                                        the empty string, use credentials from ~/.aws.
+                                        
+                                                For GS buckets: An identity flag may contain a GCP service account
+                                        (identified by an email address). Requests to Google Storage (gs://) are
+                                        always authenticated as one of our service accounts by GKE's Workload
+                                        Identity feature: https://cloud.google.com/kubernetes-engine/docs/how-
+                                        to/workload-identity. If
+                                        an identity flag is set, facilitator will use its default service account to
+                                        impersonate a different account, which should have permissions to write to
+                                        or read from the named bucket. If an identity flag is omitted or is the
+                                        empty string, the default service account exposed by the GKE metadata
+                                        service is used. Keys: All keys are P-256. Public keys are base64-encoded
+                                        DER SPKI. Private keys are in the base64 encoded format expected by libprio-
+                                        rs, or base64-encoded PKCS#8, as documented. 
+    aggregate-worker                    Consume aggregate tasks from a queue.
+                                        
+                                        Storage arguments: Any flag ending in -input or -output can take an S3
+                                        bucket (s3://<region>/<bucket>), a Google Storage bucket (gs://), or a local
+                                        directory name. The corresponding -identity flag specifies what identity to
+                                        use with a bucket.
+                                        
+                                                For S3 buckets: An identity flag may contain an AWS IAM role,
+                                        specified using an ARN (i.e. "arn:..."). Facilitator will assume that role
+                                        using an OIDC auth token obtained from the GKE metadata service. Appropriate
+                                        mappings need to be in place from Facilitator's k8s service account to its
+                                        GCP service account to the IAM role. If the identity flag is omitted or is
+                                        the empty string, use credentials from ~/.aws.
+                                        
+                                                For GS buckets: An identity flag may contain a GCP service account
+                                        (identified by an email address). Requests to Google Storage (gs://) are
+                                        always authenticated as one of our service accounts by GKE's Workload
+                                        Identity feature: https://cloud.google.com/kubernetes-engine/docs/how-
+                                        to/workload-identity. If
+                                        an identity flag is set, facilitator will use its default service account to
+                                        impersonate a different account, which should have permissions to write to
+                                        or read from the named bucket. If an identity flag is omitted or is the
+                                        empty string, the default service account exposed by the GKE metadata
+                                        service is used. Keys: All keys are P-256. Public keys are base64-encoded
+                                        DER SPKI. Private keys are in the base64 encoded format expected by libprio-
+                                        rs, or base64-encoded PKCS#8, as documented. 
+    generate-ingestion-sample           Generate sample data files
+    generate-ingestion-sample-worker    Spawn a worker to generate sample data files
+    help                                Prints this message or the help of the given subcommand(s)
+    intake-batch                        Validate an input share (from an ingestor's bucket) and emit a validation
+                                        share.
+                                        
+                                        Storage arguments: Any flag ending in -input or -output can take an S3
+                                        bucket (s3://<region>/<bucket>), a Google Storage bucket (gs://), or a local
+                                        directory name. The corresponding -identity flag specifies what identity to
+                                        use with a bucket.
+                                        
+                                                For S3 buckets: An identity flag may contain an AWS IAM role,
+                                        specified using an ARN (i.e. "arn:..."). Facilitator will assume that role
+                                        using an OIDC auth token obtained from the GKE metadata service. Appropriate
+                                        mappings need to be in place from Facilitator's k8s service account to its
+                                        GCP service account to the IAM role. If the identity flag is omitted or is
+                                        the empty string, use credentials from ~/.aws.
+                                        
+                                                For GS buckets: An identity flag may contain a GCP service account
+                                        (identified by an email address). Requests to Google Storage (gs://) are
+                                        always authenticated as one of our service accounts by GKE's Workload
+                                        Identity feature: https://cloud.google.com/kubernetes-engine/docs/how-
+                                        to/workload-identity. If
+                                        an identity flag is set, facilitator will use its default service account to
+                                        impersonate a different account, which should have permissions to write to
+                                        or read from the named bucket. If an identity flag is omitted or is the
+                                        empty string, the default service account exposed by the GKE metadata
+                                        service is used. Keys: All keys are P-256. Public keys are base64-encoded
+                                        DER SPKI. Private keys are in the base64 encoded format expected by libprio-
+                                        rs, or base64-encoded PKCS#8, as documented. 
+    intake-batch-worker                 Consume intake batch tasks from a queue, validating an input share (from an
+                                        ingestor's bucket) and emit a validation share.
+                                        
+                                        Storage arguments: Any flag ending in -input or -output can take an S3
+                                        bucket (s3://<region>/<bucket>), a Google Storage bucket (gs://), or a local
+                                        directory name. The corresponding -identity flag specifies what identity to
+                                        use with a bucket.
+                                        
+                                                For S3 buckets: An identity flag may contain an AWS IAM role,
+                                        specified using an ARN (i.e. "arn:..."). Facilitator will assume that role
+                                        using an OIDC auth token obtained from the GKE metadata service. Appropriate
+                                        mappings need to be in place from Facilitator's k8s service account to its
+                                        GCP service account to the IAM role. If the identity flag is omitted or is
+                                        the empty string, use credentials from ~/.aws.
+                                        
+                                                For GS buckets: An identity flag may contain a GCP service account
+                                        (identified by an email address). Requests to Google Storage (gs://) are
+                                        always authenticated as one of our service accounts by GKE's Workload
+                                        Identity feature: https://cloud.google.com/kubernetes-engine/docs/how-
+                                        to/workload-identity. If
+                                        an identity flag is set, facilitator will use its default service account to
+                                        impersonate a different account, which should have permissions to write to
+                                        or read from the named bucket. If an identity flag is omitted or is the
+                                        empty string, the default service account exposed by the GKE metadata
+                                        service is used. Keys: All keys are P-256. Public keys are base64-encoded
+                                        DER SPKI. Private keys are in the base64 encoded format expected by libprio-
+                                        rs, or base64-encoded PKCS#8, as documented. 
+    lint-manifest                       Validate and print out global or specific manifests
+    validate-ingestion-sample-worker    Spawn a worker to validate aggregated ingestion samples
+
+```

--- a/facilitator/tests/cmd/validate-ingestion-sample-worker.trycmd
+++ b/facilitator/tests/cmd/validate-ingestion-sample-worker.trycmd
@@ -1,0 +1,101 @@
+```
+$ facilitator validate-ingestion-sample-worker --help
+facilitator-validate-ingestion-sample-worker 
+Spawn a worker to validate aggregated ingestion samples
+
+USAGE:
+    facilitator validate-ingestion-sample-worker [OPTIONS] --instance-name <NAME> --packet-count <INT> --task-queue-kind <task-queue-kind> --task-queue-name <task-queue-name>
+
+FLAGS:
+    -h, --help       
+            Prints help information
+
+    -V, --version    
+            Prints version information
+
+
+OPTIONS:
+        --aws-sqs-region <aws-sqs-region>
+            AWS region in which to use SQS [env: AWS_SQS_REGION=]
+
+        --facilitator-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If facilitator-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the
+            specified GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            FACILITATOR_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --facilitator-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket facilitator. May not be set if facilitator-use-
+            default-aws-credentials-provider is true. Should only be set when running in GKE. [env:
+            FACILITATOR_IDENTITY=]
+        --facilitator-manifest-base-url <URL>
+            Base URL of the Facilitator manifest [env: FACILITATOR_MANIFEST_BASE_URL=]
+
+        --facilitator-output <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: FACILITATOR_OUTPUT=]
+
+        --facilitator-use-default-aws-credentials-provider <BOOL>
+            If true and facilitator-identity is unset, the default AWS credentials provider will be used when using S3
+            APIs for facilitator bucket. If false or unset and facilitator-identity is unset, a web identity provider
+            configured from the Kubernetes environment will be used. If false or unset and facilitator-identity is set,
+            a web identity provider configured from the GKE metadata service is used. May not be set to true if
+            facilitator-identity is set. Should only be set to true if running in AWS. [env:
+            FACILITATOR_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]  [possible values: true, false]
+        --gcp-project-id <gcp-project-id>
+            The GCP Project ID in which the PubSub topic implementing the work queue was created. Required if the task
+            queue is a PubSub topic. [env: GCP_PROJECT_ID=]
+        --instance-name <NAME>
+            Name of this data share processor instance, to be used to look up manifests to discover resources owned by
+            this server and peers. e.g., the instance for the state "zc" and ingestor server "megacorp" would be "zc-
+            megacorp". [env: INSTANCE_NAME=]
+    -p, --packet-count <INT>                                                          
+            Number of data packets to generate
+
+        --pha-gcp-sa-to-impersonate-before-assuming-role <SERVICE_ACCOUNT>
+            If pha-identity is an AWS IAM role and running in GCP, an identity token will be obtained for the specified
+            GCP service account to then assume the AWS IAM role using STS AssumeRoleWithWebIdentity. [env:
+            PHA_GCP_SA_TO_IMPERSONATE_BEFORE_ASSUMING_ROLE=]
+        --pha-identity <IAM_ROLE_OR_SERVICE_ACCOUNT>
+            Identity to assume when using S3 or GS APIs for bucket pha. May not be set if pha-use-default-aws-
+            credentials-provider is true. Should only be set when running in GKE. [env:
+            PHA_IDENTITY=]
+        --pha-manifest-base-url <URL>
+            Base URL of the Public Health Authority manifest [env: PHA_MANIFEST_BASE_URL=]
+
+        --pha-output <PATH>
+            Storage path (gs://, s3:// or local dir name) [env: PHA_OUTPUT=]
+
+        --pha-use-default-aws-credentials-provider <BOOL>
+            If true and pha-identity is unset, the default AWS credentials provider will be used when using S3 APIs for
+            pha bucket. If false or unset and pha-identity is unset, a web identity provider configured from the
+            Kubernetes environment will be used. If false or unset and pha-identity is set, a web identity provider
+            configured from the GKE metadata service is used. May not be set to true if pha-identity is set. Should only
+            be set to true if running in AWS. [env: PHA_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]
+            [possible values: true, false]
+        --pubsub-api-endpoint <pubsub-api-endpoint>
+            API endpoint for GCP PubSub. Optional. [env: PUBSUB_API_ENDPOINT=]  [default: https://pubsub.googleapis.com]
+
+        --rejected-topic <rejected-topic>
+            Name of topic associated with the rejected task queue. Tasks that result in non-retryable failures will be
+            forwarded to this topic, and acknowledged and removed from the task queue. If no rejected task topic is,
+            provided, the task will not be acknowledged, and it is expected the queue will eventually move the task to
+            the dead letter queue instead, once it has exhausted its retries. [env: REJECTED_TOPIC=]
+        --task-queue-identity <task-queue-identity>
+            Identity to assume when accessing task queue. Should only be set when running under GKE and task-queue-kind
+            is PubSub. [env: TASK_QUEUE_IDENTITY=]
+        --task-queue-kind <task-queue-kind>
+            kind of task queue to use [env: TASK_QUEUE_KIND=]  [possible values: gcp-pubsub, aws-sqs]
+
+        --task-queue-name <task-queue-name>
+            Name of queue from which tasks should be pulled. On GCP, a PubSub subscription ID. On AWS, an SQS queue URL.
+            [env: TASK_QUEUE_NAME=]
+        --task-queue-use-default-aws-credentials-provider <BOOL>
+            Whether to use the default AWS credentials provider when using SQS APIs. If unset and task-queue-kind is
+            SQS, uses a web identity provider configured from Kubernetes environment. Should not be set unless task-
+            queue-kind is SQS. [env: TASK_QUEUE_USE_DEFAULT_AWS_CREDENTIALS_PROVIDER=]  [default: false]  [possible
+            values: true, false]
+        --worker-maximum-lifetime <SECONDS>
+            Specifies the maximum lifetime of a worker in seconds. After this amount of time, workers will terminate
+            successfully. Termination may not be immediate: workers may choose to complete their current work item
+            before terminating, but in all cases workers will not start a new work item after their lifetime is
+            complete. [env: WORKER_MAXIMUM_LIFETIME=]
+
+```


### PR DESCRIPTION
This adds reference tests for the `--help` output of each subcommand. Such reference tests are the first recommended step in migrating to the next version of clap.