### PR TITLE
Update stackdriver-exporter Helm chart to 2.2.0

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -108,6 +108,6 @@ default_portal_server_manifest_base_url        = "manifest.global.enpa-pha.io"
 prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
-stackdriver_exporter_helm_chart_version = "1.12.0"
+stackdriver_exporter_helm_chart_version = "2.2.0"
 
 allowed_aws_account_ids = ["718214359651"]

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -248,6 +248,6 @@ enable_key_rotation_localities = ["*"]
 prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
-stackdriver_exporter_helm_chart_version = "1.12.0"
+stackdriver_exporter_helm_chart_version = "2.2.0"
 
 allowed_aws_account_ids = ["338276578713"]

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -58,6 +58,6 @@ default_portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"
 prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
-stackdriver_exporter_helm_chart_version = "1.12.0"
+stackdriver_exporter_helm_chart_version = "2.2.0"
 
 allowed_aws_account_ids = ["024759592502"]

--- a/terraform/variables/stg-us-facil.tfvars
+++ b/terraform/variables/stg-us-facil.tfvars
@@ -99,6 +99,6 @@ single_object_validation_batch_localities = ["gondor", "narnia"]
 prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
-stackdriver_exporter_helm_chart_version = "1.12.0"
+stackdriver_exporter_helm_chart_version = "2.2.0"
 
 allowed_aws_account_ids = ["183375168988"]

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -104,6 +104,6 @@ single_object_validation_batch_localities = ["gondor", "narnia"]
 prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
-stackdriver_exporter_helm_chart_version = "1.12.0"
+stackdriver_exporter_helm_chart_version = "2.2.0"
 
 allowed_aws_account_ids = ["183375168988"]


### PR DESCRIPTION
This update includes a number of small chart changes, and a version update for its exporter container. The only breaking change concerns a value we do not set.