### PR TITLE
Update Rusoto 0.47.0 -> 0.48.0.

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -557,15 +557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct 0.6.0",
-]
-
-[[package]]
 name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,7 +708,7 @@ dependencies = [
  "hmac 0.12.1",
  "http",
  "hyper",
- "hyper-rustls 0.23.0",
+ "hyper-rustls",
  "jsonwebtoken",
  "lazy_static",
  "mockito",
@@ -1158,23 +1149,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "ct-logs",
- "futures-util",
- "hyper",
- "log",
- "rustls 0.19.0",
- "rustls-native-certs 0.5.0",
- "tokio",
- "tokio-rustls 0.22.0",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
@@ -1182,10 +1156,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.20.2",
- "rustls-native-certs 0.6.1",
+ "rustls",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.23.2",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1975,9 +1949,9 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rusoto_core"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
+checksum = "1db30db44ea73551326269adcf7a2169428a054f14faf9e1768f2163494f2fa2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1986,7 +1960,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-rustls 0.22.1",
+ "hyper-rustls",
  "lazy_static",
  "log",
  "rusoto_credential",
@@ -2000,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_credential"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a46b67db7bb66f5541e44db22b0a02fed59c9603e146db3a9e633272d3bac2f"
+checksum = "ee0a6c13db5aad6047b6a44ef023dbbc21a056b6dab5be3b79ce4283d5c02d05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2018,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_mock"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b3ad822f9ff58043dc81172a27f392e2f2aedebd8566c5f4bee4bfd2be021a"
+checksum = "5a384880f3c6d514e9499e6df75490bef5f6f39237bc24844e3933dfc09e9e55"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2033,9 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_s3"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048c2fe811a823ad5a9acc976e8bf4f1d910df719dcf44b15c3e96c5b7a51027"
+checksum = "7aae4677183411f6b0b412d66194ef5403293917d66e70ab118f07cc24c5b14d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2046,9 +2020,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_signature"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
+checksum = "a5ae95491c8b4847931e291b151127eccd6ff8ca13f33603eb3d0035ecb05272"
 dependencies = [
  "base64",
  "bytes",
@@ -2072,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_sns"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0bea954002f259d138d87c6b79e0bc02517e8edb31175ac006ad79ce946377"
+checksum = "bd3b5825c5ca2869303945a7d9125b66bf2f0901463066182945eafda5d7f68c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2086,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_sqs"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae091bb560b2aa3b6ec2ab8224516b63f6b6f7c495ae4e41f0566089b156e5f"
+checksum = "5218423da8976dfc3f14c72d602681c9cedb0cfa29eddb5c36a440eca6444131"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2100,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_sts"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7edd42473ac006fd54105f619e480b0a94136e7f53cf3fb73541363678fd92"
+checksum = "d1643f49aa67cb7cb895ebac5a2ff3f991c6dbdc58ad98b28158cd5706aecd1d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2124,39 +2098,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
-dependencies = [
- "base64",
- "log",
- "ring",
- "sct 0.6.0",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
 dependencies = [
  "log",
  "ring",
- "sct 0.7.0",
- "webpki 0.22.0",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
-dependencies = [
- "openssl-probe",
- "rustls 0.19.0",
- "schannel",
- "security-framework",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -2228,16 +2177,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sct"
@@ -2814,24 +2753,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.0",
- "tokio",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
- "rustls 0.20.2",
+ "rustls",
  "tokio",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -3116,11 +3044,11 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.20.2",
+ "rustls",
  "serde",
  "serde_json",
  "url",
- "webpki 0.22.0",
+ "webpki",
  "webpki-roots",
 ]
 
@@ -3314,16 +3242,6 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -3338,7 +3256,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
 dependencies = [
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -34,11 +34,11 @@ prometheus = { version = "0.13", features = ["process"] }
 rand = "0.8"
 regex = "^1.5.5"
 ring = { version = "0.16.20", features = ["std"] }
-rusoto_core = { version = "^0.47", default_features = false, features = ["rustls"] }
-rusoto_s3 = { version = "^0.47", default_features = false, features = ["rustls"] }
-rusoto_sns = { version = "^0.47", default_features = false, features = ["rustls"] }
-rusoto_sqs = { version = "^0.47", default_features = false, features = ["rustls"] }
-rusoto_sts = { version = "^0.47", default_features = false, features = ["rustls"] }
+rusoto_core = { version = "^0.48", default_features = false, features = ["rustls"] }
+rusoto_s3 = { version = "^0.48", default_features = false, features = ["rustls"] }
+rusoto_sns = { version = "^0.48", default_features = false, features = ["rustls"] }
+rusoto_sqs = { version = "^0.48", default_features = false, features = ["rustls"] }
+rusoto_sts = { version = "^0.48", default_features = false, features = ["rustls"] }
 sha2 = "0.10"
 slog = { version = "2.7.0", features = ["max_level_trace"] }
 slog-async = "2.7.0"
@@ -67,5 +67,5 @@ xml-rs = "0.8"
 assert_matches = "1.5.0"
 hex = "0.4.3"
 mockito = "0.31.0"
-rusoto_mock = { version = "^0.47", default_features = false, features = ["rustls"] }
+rusoto_mock = { version = "^0.48", default_features = false, features = ["rustls"] }
 serde_test = "1.0"

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -629,7 +629,13 @@ mod tests {
             String::from(TEST_KEY),
             50,
             S3Client::new_with(
-                HttpClient::new().unwrap(),
+                HttpClient::from_connector(
+                    HttpsConnectorBuilder::new()
+                        .with_native_roots()
+                        .https_or_http()
+                        .enable_http1()
+                        .build(),
+                ),
                 aws_credentials::Provider::new_mock(&logger, &api_metrics),
                 Region::Custom {
                     name: TEST_REGION.into(),
@@ -676,7 +682,13 @@ mod tests {
             String::from(TEST_KEY),
             50,
             S3Client::new_with(
-                HttpClient::new().unwrap(),
+                HttpClient::from_connector(
+                    HttpsConnectorBuilder::new()
+                        .with_native_roots()
+                        .https_or_http()
+                        .enable_http1()
+                        .build(),
+                ),
                 aws_credentials::Provider::new_mock(&logger, &api_metrics),
                 Region::Custom {
                     name: TEST_REGION.into(),
@@ -743,7 +755,13 @@ mod tests {
             String::from(TEST_KEY),
             50,
             S3Client::new_with(
-                HttpClient::new().unwrap(),
+                HttpClient::from_connector(
+                    HttpsConnectorBuilder::new()
+                        .with_native_roots()
+                        .https_or_http()
+                        .enable_http1()
+                        .build(),
+                ),
                 aws_credentials::Provider::new_mock(&logger, &api_metrics),
                 Region::Custom {
                     name: TEST_REGION.into(),
@@ -809,7 +827,13 @@ mod tests {
             String::from(TEST_KEY),
             50,
             S3Client::new_with(
-                HttpClient::new().unwrap(),
+                HttpClient::from_connector(
+                    HttpsConnectorBuilder::new()
+                        .with_native_roots()
+                        .https_or_http()
+                        .enable_http1()
+                        .build(),
+                ),
                 aws_credentials::Provider::new_mock(&logger, &api_metrics),
                 Region::Custom {
                     name: TEST_REGION.into(),


### PR DESCRIPTION
I also had to modify a few tests to manually create an HTTP connector
due to a breaking change to make HttpClient support HTTPS only by
default in
https://github.com/rusoto/rusoto/commit/df317924d260ef002a8596b303902eb8d9298e24.