### PR TITLE
Add alert for low packet ingestion rate

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -155,3 +155,12 @@ groups:
       summary: "Container is stuck waiting"
       description: "Container {{ $labels.container }} has been waiting for fifteen minutes, in pod
         {{ $labels.pod }}, namespace {{ $labels.exported_namespace }}, and environment ${environment}."
+  - alert: ingest_rate_low
+    expr: sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[16h])) < 0.25 * sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[16h] offset 1d))
+    labels:
+      severity: page
+      environment: ${environment}
+    annotations:
+      summary: "The rate of intake processing has dropped off steeply compared to yesterday."
+      description: "The number of packets from {{ $labels.service }} in locality
+        {{ $labels.namespace }} and environment ${environment} is low relative to past levels."

--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -156,7 +156,8 @@ groups:
       description: "Container {{ $labels.container }} has been waiting for fifteen minutes, in pod
         {{ $labels.pod }}, namespace {{ $labels.exported_namespace }}, and environment ${environment}."
   - alert: ingest_rate_low
-    expr: sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[16h])) < 0.25 * sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[16h] offset 1d))
+    expr: sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[16h])) < 0.25 *
+      sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[16h] offset 1d))
     labels:
       severity: page
       environment: ${environment}


### PR DESCRIPTION
This adds a new alerting rule to address #1609. The main constraint I had to design around was the spikiness of incoming data in Apple ingestion buckets. If this changes in the future, we could adjust this alerting rule to be both stricter and quicker-acting.

The two key calibration parameters are the averaging time period of 16 hours, and the relative alarming threshold at 0.25x of historical ingestion rate. I chose to average the rates over 16 hours because, over the last two weeks, the longest duration that any one locality went between bursts of packets was about 14 hours. Then, looking at those averaged rates, normal values fluctuated with a dynamic range of up to ~3.5x, so the relative threshold of 0.25x should avoid false alarms.

I tested this expression against historical data, and it would have alarmed for ~27 hours on the four localities where we saw data loss.