### PR TITLE
Add optional var for permissions boundary policy

### DIFF
--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -142,6 +142,11 @@ indicates that all localities should generate single-object validation batches.
 DESCRIPTION
 }
 
+variable "role_permissions_boundary_policy_arn" {
+  type    = string
+  default = null
+}
+
 # We need the ingestion server's manifest so that we can discover the GCP
 # service account it will use to upload ingestion batches. Some ingestors
 # (Apple) are singletons, and advertise a single global manifest which contains
@@ -279,6 +284,7 @@ resource "aws_iam_role" "bucket_role" {
       }
     ]
   })
+  permissions_boundary = var.role_permissions_boundary_policy_arn
 }
 
 # The bucket_role defined above is created in our AWS account and used to

--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -63,6 +63,11 @@ variable "aggregate_queues" {
   }))
 }
 
+variable "role_permissions_boundary_policy_arn" {
+  type    = string
+  default = null
+}
+
 # TODO(brandon): this module is messy in that it conflates own/peer with facilitator/pha. (In
 # practice, "own" = "facilitator" & "peer" = "pha".) This should be cleaned up to drop the own/peer
 # terminology in favor of facilitator/pha.
@@ -87,7 +92,7 @@ resource "aws_iam_role" "tester_role" {
   # requesting tokens from the GKE metadata service in
   # S3Transport::new_with_client
   # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
-  assume_role_policy = <<ROLE
+  assume_role_policy   = <<ROLE
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -107,6 +112,7 @@ resource "aws_iam_role" "tester_role" {
   ]
 }
 ROLE
+  permissions_boundary = var.role_permissions_boundary_policy_arn
 }
 
 resource "aws_iam_role_policy" "bucket_role_policy" {


### PR DESCRIPTION
This allows setting a permissions boundary policy on all AWS IAM roles created in a non-pure GCP environment.

This is the first part of IN-7312; it will make writing and testing policies easier.