### PR TITLE
terraform: Explicitly specify 'standard' boot disk

### DIFF
--- a/terraform/cluster_bootstrap/modules/gke/gke.tf
+++ b/terraform/cluster_bootstrap/modules/gke/gke.tf
@@ -120,6 +120,7 @@ resource "google_container_node_pool" "worker_nodes" {
   }
   node_config {
     disk_size_gb = "25"
+    disk_type    = "pd-standard"
     image_type   = "COS_CONTAINERD"
     machine_type = var.cluster_settings.gcp_machine_type
     oauth_scopes = [


### PR DESCRIPTION
This will keep us using "pd-standard" boot disks, even after the defaults for new node pools change. I checked the plans with this applied, and there was no diff, as the default value of "pd-standard" is already recorded in the state.