### PR TITLE
Upgrade to AWS for Fluent Bit 2.25.0

### DIFF
--- a/terraform/modules/eks/log.tf
+++ b/terraform/modules/eks/log.tf
@@ -172,7 +172,7 @@ resource "kubernetes_daemonset" "fluent_bit" {
 
         container {
           name              = "fluent-bit"
-          image             = "amazon/aws-for-fluent-bit:2.23.1"
+          image             = "amazon/aws-for-fluent-bit:2.25.0"
           image_pull_policy = "Always"
 
           env {


### PR DESCRIPTION
This upgrade includes a new feature to automatically refresh Kubernetes service account tokens, which is necessary in Kubernetes 1.21.

I have tested this on my cluster, and log collection still works fine. This will address the issue noted in the emails from AWS today. The relevant pods are 51 days old now, and tokens currently expire at 90 days, so we have plenty of time to resolve this. I propose merging this after the next production deploy, and picking it up in next week's deploys.