### PR TITLE
Recalibrate ingest_rate_low alert

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -156,8 +156,8 @@ groups:
       description: "Container {{ $labels.container }} has been waiting for fifteen minutes, in pod
         {{ $labels.pod }}, namespace {{ $labels.exported_namespace }}, and environment ${environment}."
   - alert: ingest_rate_low
-    expr: sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[16h])) < 0.25 *
-      sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[16h] offset 1d))
+    expr: sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[20h])) < 0.25 *
+      sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[20h] offset 1d))
     labels:
       severity: page
       environment: ${environment}


### PR DESCRIPTION
The temporal distribution of reports from Apple ingest servers changed two days ago. There are still three peaks a day, but the peaks are broader, shorter, and arrive at different times. The gap between two peaks yesterday evening was significantly longer than seen previously. This change adjusts the low ingestion rate alert to adapt to the new behavior.