### PR TITLE
Dependency and Prometheus Cleanups

### DIFF
--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -32,7 +32,6 @@ pkix = "0.1.2"
 prio = "0.6.1"
 prometheus = { version = "0.13", features = ["process"] }
 rand = "0.8"
-regex = "^1.5.6"
 ring = { version = "0.16.20", features = ["std"] }
 rusoto_core = { version = "^0.48", default_features = false, features = ["rustls"] }
 rusoto_s3 = { version = "^0.48", default_features = false, features = ["rustls"] }
@@ -67,5 +66,6 @@ xml-rs = "0.8"
 assert_matches = "1.5.0"
 hex = "0.4.3"
 mockito = "0.31.0"
+regex = "^1.5.6"
 rusoto_mock = { version = "^0.48", default_features = false, features = ["rustls"] }
 serde_test = "1.0"

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -196,23 +196,3 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:fdedf610e0d020878a8f1fedda8105e0c33a7e23c4792fca54460685552de308",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/tls" {
-  version     = "3.4.0"
-  constraints = "3.4.0"
-  hashes = [
-    "h1:oyllIA9rNGCFtClSyBitUIzCXdnKtspVepdsvpLlfys=",
-    "zh:2442a0df0cfb550b8eba9b2af39ac06f54b62447eb369ecc6b1c29f739b33bbb",
-    "zh:3ebb82cacb677a099de55f844f0d02886bc804b1a2b94441bc40fabcb64d2a38",
-    "zh:436125c2a7e66bc62a4a7c68bdca694f071d7aa894e8637dc83f4a68fe322546",
-    "zh:5f03db9f1d77e8274ff4750ae32d5c16c42b862b06bcb0683e4d733c8db922e4",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8190142ae8a539ab34193b7e75da0fa04035d1dcd8af8be94df1eafeeffb44b6",
-    "zh:8cdc7cd9221e27c189e5beaf78462fce4c2edb081f415a1eafc6da2949de31e2",
-    "zh:a5de0f7f5d63c59ebf61d3c1d94040f410665ff0aa04f66674efe24b39a11f94",
-    "zh:a9fce48db3c140cc3e06f8a3c7ef4d36735e457e7660442d6d5dcd2b0781adc3",
-    "zh:beb92de584c790c7c7f047e45ccd22b6ee3263c7b5a91ae4d6882ae6e7700570",
-    "zh:f373f8cc52846fb513f44f468d885f722ca4dc22af9ff1942368cafd16b796b3",
-    "zh:f69627fd6e5a920b17ff423cdbad2715078ca6d13146dc67668795582ab43748",
-  ]
-}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -381,11 +381,6 @@ terraform {
       source  = "hashicorp/random"
       version = "3.2.0"
     }
-    # `tls` provider needed to load EKS cluster OIDC provider certificate
-    tls = {
-      source  = "hashicorp/tls"
-      version = "3.4.0"
-    }
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = "1.14.0"


### PR DESCRIPTION
This includes three small cleanups that came up while going over dependency updates.

1. `regex` can be a dev-dependency, as it is only used in tests.
2. There is a `const` in the Prometheus crate we can use for the text format media type.
3. `hashicorp/tls` is only used in the `cluster_bootstrap` module, but it was specified in both `main.tf` files.