### PR TITLE
terraform: fix Prometheus labels on task alerts

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -23,9 +23,9 @@ groups:
       environment: ${environment}
     annotations:
       summary: "High failure rate for intake worker
-        {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
-      description: "intake worker instance {{ $labels.kubernetes_namespace }}-
-        {{ $labels.kubernetes_name }} in environment ${environment} is failing
+        {{ $labels.namespace }}-{{ $labels.service }}"
+      description: "intake worker instance {{ $labels.namespace }}-
+        {{ $labels.service }} in environment ${environment} is failing
         more than 5% of the time in the last hour"
   - alert: facilitator_aggregate_failure_rate
     # aggregations run much less often than intake so use a larger window of time
@@ -37,9 +37,9 @@ groups:
       environment: ${environment}
     annotations:
       summary: "High failure rate for aggregate worker
-        {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
-      description: "aggregate worker instance {{ $labels.kubernetes_namespace}}-
-        {{ $labels.kubernetes_name }} in environment ${environment} is failing
+        {{ $labels.namespace }}-{{ $labels.service }}"
+      description: "aggregate worker instance {{ $labels.namespace}}-
+        {{ $labels.service }} in environment ${environment} is failing
         more than 5% of the time in the last 8 hours"
   - alert: facilitator_intake_rejection_rate
     expr: (sum without (status) (rate(facilitator_intake_tasks_finished{status="rejected"}[1h])))
@@ -50,9 +50,9 @@ groups:
       environment: ${environment}
     annotations:
       summary: "High rejection rate for intake worker
-        {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
-      description: "intake worker instance {{ $labels.kubernetes_namespace }}-
-        {{ $labels.kubernetes_name }} in environment ${environment} has
+        {{ $labels.namespace }}-{{ $labels.service }}"
+      description: "intake worker instance {{ $labels.namespace }}-
+        {{ $labels.service }} in environment ${environment} has
         rejected more than 1% of tasks in the last hour"
   - alert: facilitator_aggregate_rejection_rate
     expr: (sum without (status) (rate(facilitator_aggregate_tasks_finished{status="rejected"}[${aggregation_period}])))
@@ -63,9 +63,9 @@ groups:
       environment: ${environment}
     annotations:
       summary: "High rejection rate for aggregate worker
-        {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
-      description: "aggregate worker instance {{ $labels.kubernetes_namespace }}-
-        {{ $labels.kubernetes_name }} in environment ${environment} has
+        {{ $labels.namespace }}-{{ $labels.service }}"
+      description: "aggregate worker instance {{ $labels.namespace }}-
+        {{ $labels.service }} in environment ${environment} has
         rejected more than 1% of tasks in the last 8 hours"
   - alert: intake_task_queue_growth
     expr: min_over_time(stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{subscription_id!~".*-dead-letter",subscription_id=~".*-intake"}[30m]) > 0


### PR DESCRIPTION
The metrics `facilitator_intake_tasks_finished` and `facilitator_aggregate_tasks_finished` do not have `kubernetes_namespace` or `kubernetes_name` labels with our current relabeling configuration.