### PR TITLE
Upgrade Prometheus Helm chart

### DIFF
--- a/terraform/modules/monitoring/http_api_dashboard.json
+++ b/terraform/modules/monitoring/http_api_dashboard.json
@@ -105,7 +105,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "exemplar": true,
-          "expr": "sum by (exported_service, endpoint, status) (rate(facilitator_api_latency_ms_count{status!~\"200|success\"}[20m]) unless rate(facilitator_api_latency_ms_count{exported_service=\"storage.googleapis.com\", endpoint=\"cancel-upload\", status=\"499\"}[20m])) / ignoring(status) group_left sum by (exported_service, endpoint) (rate(facilitator_api_latency_ms_count[20m])) * 100",
+          "expr": "sum by (service, endpoint, status) (rate(facilitator_api_latency_ms_count{status!~\"200|success\"}[20m]) unless rate(facilitator_api_latency_ms_count{service=\"storage.googleapis.com\", endpoint=\"cancel-upload\", status=\"499\"}[20m])) / ignoring(status) group_left sum by (service, endpoint) (rate(facilitator_api_latency_ms_count[20m])) * 100",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -194,7 +194,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "exemplar": true,
-          "expr": "sum by (exported_service, endpoint) (rate(facilitator_api_latency_ms_count[20m]))",
+          "expr": "sum by (service, endpoint) (rate(facilitator_api_latency_ms_count[20m]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -137,7 +137,7 @@ groups:
       summary: "prometheus-server low disk space"
       description: "There is less than 30% available disk space on the prometheus-server PersistentVolumeClaim"
   - alert: kubernetes_pod_restarting
-    expr: (increase(kube_pod_container_status_restarts_total[15m]) * on (exported_namespace, pod) group_left kube_pod_info) > 2
+    expr: (increase(kube_pod_container_status_restarts_total[15m]) * on (namespace, pod) group_left kube_pod_info) > 2
     for: 5m
     labels:
       severity: page
@@ -145,7 +145,7 @@ groups:
     annotations:
       summary: "Container is in a restart loop"
       description: "Container {{ $labels.container }} is restarting repeatedly in
-        pod {{ $labels.pod }}, namespace {{ $labels.exported_namespace }}, and environment ${environment}."
+        pod {{ $labels.pod }}, namespace {{ $labels.namespace }}, and environment ${environment}."
   - alert: kubernetes_pod_waiting
     expr: min_over_time(kube_pod_container_status_waiting[15m]) * kube_pod_container_status_waiting * (kube_pod_container_status_waiting offset 15m) > 0
     labels:
@@ -154,7 +154,7 @@ groups:
     annotations:
       summary: "Container is stuck waiting"
       description: "Container {{ $labels.container }} has been waiting for fifteen minutes, in pod
-        {{ $labels.pod }}, namespace {{ $labels.exported_namespace }}, and environment ${environment}."
+        {{ $labels.pod }}, namespace {{ $labels.namespace }}, and environment ${environment}."
   - alert: ingest_rate_low
     expr: sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[20h])) < 0.25 *
       sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[20h] offset 1d))

--- a/terraform/modules/monitoring/resource_usage_dashboard.json
+++ b/terraform/modules/monitoring/resource_usage_dashboard.json
@@ -195,7 +195,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "exemplar": true,
-          "expr": "sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{container!=\"\"}[5m])) > sum by (namespace, pod, container) (label_replace(kube_pod_container_resource_requests{resource=\"cpu\"}, \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"))",
+          "expr": "sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{container!=\"\"}[5m])) > sum by (namespace, pod, container) (kube_pod_container_resource_requests{resource=\"cpu\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -284,7 +284,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "exemplar": true,
-          "expr": "sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{container!=\"\"}[5m])) unless sum by (namespace, pod, container) (label_replace(kube_pod_container_resource_requests{resource=\"cpu\"}, \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"))",
+          "expr": "sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{container!=\"\"}[5m])) unless sum by (namespace, pod, container) (kube_pod_container_resource_requests{resource=\"cpu\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -463,7 +463,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "exemplar": true,
-          "expr": "(sum by (namespace, pod, container) (container_memory_usage_bytes{container!=\"\"}) > sum by (namespace, pod, container) (label_replace(kube_pod_container_resource_requests{resource=\"memory\"}, \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"))) / 1024 / 1024",
+          "expr": "(sum by (namespace, pod, container) (container_memory_usage_bytes{container!=\"\"}) > sum by (namespace, pod, container) (kube_pod_container_resource_requests{resource=\"memory\"})) / 1024 / 1024",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -552,7 +552,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "exemplar": true,
-          "expr": "(sum by (namespace, pod, container) (container_memory_usage_bytes{container!=\"\"}) unless sum by (namespace, pod, container) (label_replace(kube_pod_container_resource_requests{resource=\"memory\"}, \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"))) / 1024 / 1024",
+          "expr": "(sum by (namespace, pod, container) (container_memory_usage_bytes{container!=\"\"}) unless sum by (namespace, pod, container) (kube_pod_container_resource_requests{resource=\"memory\"})) / 1024 / 1024",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -105,7 +105,7 @@ default_aggregation_grace_period = "4h"
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-enpa-g-prod-manifests"
 default_portal_server_manifest_base_url        = "manifest.global.enpa-pha.io"
 
-prometheus_helm_chart_version           = "15.0.2"
+prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "2.2.0"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -245,7 +245,7 @@ default_portal_server_manifest_base_url        = "manifest.enpa-pha.io"
 
 enable_key_rotation_localities = ["*"]
 
-prometheus_helm_chart_version           = "15.0.2"
+prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "2.2.0"

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -55,7 +55,7 @@ default_aggregation_grace_period = "10m"
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-server-manifests"
 default_portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"
 
-prometheus_helm_chart_version           = "15.0.2"
+prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "2.2.0"

--- a/terraform/variables/stg-us-facil.tfvars
+++ b/terraform/variables/stg-us-facil.tfvars
@@ -96,7 +96,7 @@ batch_signing_key_rotation_policy = {
 
 single_object_validation_batch_localities = ["gondor", "narnia"]
 
-prometheus_helm_chart_version           = "15.0.2"
+prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "2.2.0"

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -101,7 +101,7 @@ batch_signing_key_rotation_policy = {
 
 single_object_validation_batch_localities = ["gondor", "narnia"]
 
-prometheus_helm_chart_version           = "15.0.2"
+prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "2.2.0"


### PR DESCRIPTION
This upgrade includes a change to the "honor_labels" configuration of all scrape targets. This change affects certain Kubernetes-related label names, which are used in dashboards and alerts.