### PR TITLE
terraform: deploy 0.6.39 to production

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -94,9 +94,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-workflow_manager_version = "0.6.38"
-facilitator_version      = "0.6.38"
-key_rotator_version      = "0.6.38"
+workflow_manager_version = "0.6.39"
+facilitator_version      = "0.6.39"
+key_rotator_version      = "0.6.39"
 victorops_routing_key    = "prio-prod-intl"
 
 default_aggregation_period       = "8h"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -234,9 +234,9 @@ is_first                                  = false
 use_aws                                   = false
 default_aggregation_period                = "8h"
 default_aggregation_grace_period          = "4h"
-workflow_manager_version                  = "0.6.38"
-facilitator_version                       = "0.6.38"
-key_rotator_version                       = "0.6.38"
+workflow_manager_version                  = "0.6.39"
+facilitator_version                       = "0.6.39"
+key_rotator_version                       = "0.6.39"
 prometheus_server_persistent_disk_size_gb = 1000
 victorops_routing_key                     = "prio-prod-us"
 


### PR DESCRIPTION
The staging environments have been running well, I don't see any issues with Prometheus, Grafana, or custom metrics. The prod plans look as expected.