### PR TITLE
Update production to 0.6.41

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -94,9 +94,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-workflow_manager_version = "0.6.40"
-facilitator_version      = "0.6.40"
-key_rotator_version      = "0.6.40"
+workflow_manager_version = "0.6.41"
+facilitator_version      = "0.6.41"
+key_rotator_version      = "0.6.41"
 victorops_routing_key    = "prio-prod-intl"
 
 default_aggregation_period       = "8h"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -234,9 +234,9 @@ is_first                                  = false
 use_aws                                   = false
 default_aggregation_period                = "8h"
 default_aggregation_grace_period          = "4h"
-workflow_manager_version                  = "0.6.40"
-facilitator_version                       = "0.6.40"
-key_rotator_version                       = "0.6.40"
+workflow_manager_version                  = "0.6.41"
+facilitator_version                       = "0.6.41"
+key_rotator_version                       = "0.6.41"
 prometheus_server_persistent_disk_size_gb = 1000
 victorops_routing_key                     = "prio-prod-us"
 


### PR DESCRIPTION
As with staging, there are no changes to `cluster_bootstrap`, and the main stage's plans only show container image upgrades.