### PR TITLE
Update staging to 0.6.44

### DIFF
--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -44,9 +44,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-workflow_manager_version = "0.6.43"
-facilitator_version      = "0.6.43"
-key_rotator_version      = "0.6.43"
+workflow_manager_version = "0.6.44"
+facilitator_version      = "0.6.44"
+key_rotator_version      = "0.6.44"
 victorops_routing_key    = "prio-staging"
 
 default_aggregation_period       = "30m"

--- a/terraform/variables/stg-us-facil.tfvars
+++ b/terraform/variables/stg-us-facil.tfvars
@@ -74,9 +74,9 @@ test_peer_environment = {
 }
 is_first                 = false
 use_aws                  = false
-workflow_manager_version = "0.6.43"
-facilitator_version      = "0.6.43"
-key_rotator_version      = "0.6.43"
+workflow_manager_version = "0.6.44"
+facilitator_version      = "0.6.44"
+key_rotator_version      = "0.6.44"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -79,9 +79,9 @@ test_peer_environment = {
 }
 is_first                 = true
 use_aws                  = true
-workflow_manager_version = "0.6.43"
-facilitator_version      = "0.6.43"
-key_rotator_version      = "0.6.43"
+workflow_manager_version = "0.6.44"
+facilitator_version      = "0.6.44"
+key_rotator_version      = "0.6.44"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"


### PR DESCRIPTION
The Terraform plans look as expected, based on the spot VM changes. Note that this includes changes to `cluster_bootstrap` as well.