### PR TITLE
workflow-manager: Avoid writing 0 to time gauges

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -3,7 +3,7 @@ groups:
   rules:
   # See docs/monitoring.md for discussion of the PromQL expressions in these alerts.
   - alert: workflow_manager_heartbeat
-    expr: (time() - max_over_time(workflow_manager_last_success_seconds[1800s])) > 1800
+    expr: (time() - max_over_time(workflow_manager_last_success_seconds[3600s])) > 1800
     for: 5m
     labels:
       severity: page

--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -3,7 +3,7 @@ groups:
   rules:
   # See docs/monitoring.md for discussion of the PromQL expressions in these alerts.
   - alert: workflow_manager_heartbeat
-    expr: (time() - workflow_manager_last_success_seconds) > 1800
+    expr: (time() - max_over_time(workflow_manager_last_success_seconds[1800s])) > 1800
     for: 5m
     labels:
       severity: page

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -187,7 +187,7 @@ func main() {
 	flag.Parse()
 
 	var pusher *push.Pusher
-	// Closure that sends metrics to prometheus-gateway, if configured.
+	// Closure that sends metrics to prometheus-pushgateway, if configured.
 	var pushMetrics = func() {
 		if pusher != nil {
 			err := pusher.Push()


### PR DESCRIPTION
Our workflow-manager heartbeat alert has been firing after a single failed workflow-manager run, because this code path registered the gauge `workflow_manager_last_success_seconds`, never set its value, and sent the default value of 0 to prometheus-gateway. This PR fixes this issue by only registering success/failure gauges immediately before setting their values. It also fixes the `workflow_manager_last_failure_seconds` metric by pushing metrics after the gauge has been updated, and before `os.Exit()` is called.

I'm posting this as a draft early while I work on testing it.