### PR TITLE
workflow-manager: Store S3 client for reuse in later operations

### DIFF
--- a/workflow-manager/storage/storage.go
+++ b/workflow-manager/storage/storage.go
@@ -150,7 +150,8 @@ func (b *S3Bucket) service() (s3iface.S3API, error) {
 		return nil, err
 	}
 
-	return s3.New(sess, config), nil
+	b.s3Service = s3.New(sess, config)
+	return b.s3Service, nil
 }
 
 func (b *S3Bucket) ListAggregationIDs() ([]string, error) {


### PR DESCRIPTION
This fixes #1832. It should cut down our requests to STS by at least an order of magnitude. I confirmed that the STS requests already benefit from the SDK's retry logic. Thus, I think this change should effectively eliminate the class of STS errors we have been seeing. (beyond recent metrics/alerting-only fixes)

I tested this out on my AWS development environment, and it sped up jobs from nine seconds to three seconds, so I expect we should see a nice wall clock benefit as well in production. (prod-us takes around one minute and prod-intl takes around six minutes currently)