### PR TITLE
Add an alert for pods that are pending too long

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -155,6 +155,15 @@ groups:
       summary: "Container is stuck waiting"
       description: "Container {{ $labels.container }} has been waiting for fifteen minutes, in pod
         {{ $labels.pod }}, namespace {{ $labels.namespace }}, and environment ${environment}."
+  - alert: kubernetes_pod_pending
+    expr: kube_pod_status_phase{phase="Pending"} * (kube_pod_status_phase{phase="Pending"} offset 15m) > 0
+    labels:
+      severity: page
+      environment: ${environment}
+    annotations:
+      summary: "Pod is stuck pending scheduling"
+      description: "Pod {{ $labels.pod }} has been pending for fifteen minutes, in namespace
+        {{ $labels.namespace }} and environment ${environment}."
   - alert: ingest_rate_low
     expr: sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[20h])) < 0.25 *
       sum by (service, namespace) (rate(facilitator_intake_ingestion_packets_processed[20h] offset 1d))


### PR DESCRIPTION
This adds a new alert based on kube-state-metrics data, to check for any pods that are stuck pending. This could happen if our resources are under-provisioned, or if there's an issue with the pod's affinities or taint tolerations, relative to the rest of the cluster.

Over the last week, we have seen an increased number of pods that are pending, but only for approximately one minute. This was introduced by #1703 and will be fixed by #1816. This alert's threshold is far higher, so it will only fire if there's a more serious issue, beyond our thundering herd of cron jobs.