### PR TITLE
Add flags to collect profiles from Go programs

### DIFF
--- a/key-rotator/main.go
+++ b/key-rotator/main.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
+	"runtime/pprof"
 	"strings"
 	"sync"
 	"time"
@@ -65,6 +67,8 @@ var (
 	awsRegion                     = flag.String("aws-region", "", "If specified, the AWS `region` to use for manifest storage")
 	pushGateway                   = flag.String("push-gateway", "", "Set this to the gateway to use with prometheus. If left empty, metrics will not be pushed to prometheus.")
 	kubeconfig                    = flag.String("kubeconfig", "", "The `path` to user's kubeconfig file; if unspecified, assumed to be running in-cluster") // typical value is $HOME/.kube/config
+	cpuProfile                    = flag.String("cpuprofile", "", "Write a CPU profile to `file`")
+	memProfile                    = flag.String("memprofile", "", "Write a memory profile to `file`")
 
 	// Metrics.
 	pusher      *push.Pusher // populated only if --push-gateway is specified.
@@ -100,6 +104,24 @@ func main() {
 		// If we are running on someone's workstation, get nice pretty-printed
 		// log lines instead of structured JSON.
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	}
+
+	if *cpuProfile != "" {
+		f, err := os.Create(*cpuProfile)
+		if err != nil {
+			fail("could not create CPU profile: %v", err)
+		}
+		defer func() {
+			err := f.Close()
+			if err != nil {
+				log.Err(err).Msg("could not close CPU profile")
+			}
+		}()
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			fail("could not start CPU file: %v", err)
+		}
+		defer pprof.StopCPUProfile()
 	}
 
 	switch {
@@ -276,6 +298,25 @@ func main() {
 	if err := tryPushMetrics(); err != nil {
 		log.Error().Err(err).Msgf("Couldn't push metrics: %v", err)
 	}
+
+	if *memProfile != "" {
+		f, err := os.Create(*memProfile)
+		if err != nil {
+			fail("could not create memory profile: %v", err)
+		}
+		defer func() {
+			err := f.Close()
+			if err != nil {
+				log.Err(err).Msg("could not close CPU profile")
+			}
+		}()
+		runtime.GC()
+		err = pprof.WriteHeapProfile(f)
+		if err != nil {
+			fail("could not write memory profile: %v", err)
+		}
+	}
+
 	log.Info().Msgf("Keys rotated successfully")
 }
 


### PR DESCRIPTION
This adds `-cpuprofile` and `-memprofile` flags to both workflow-manager and key-rotator. This is part of #1757.