### PR TITLE
terraform: Add option to collect heap profiles

### DIFF
--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -147,6 +147,14 @@ variable "role_permissions_boundary_policy_arn" {
   default = null
 }
 
+variable "enable_heap_profiles" {
+  type = bool
+}
+
+variable "profile_nfs_server" {
+  type = string
+}
+
 # We need the ingestion server's manifest so that we can discover the GCP
 # service account it will use to upload ingestion batches. Some ingestors
 # (Apple) are singletons, and advertise a single global manifest which contains
@@ -424,6 +432,8 @@ module "kubernetes" {
   aws_region                                = var.aws_region
   gcp_workload_identity_pool_provider       = var.gcp_workload_identity_pool_provider
   single_object_validation_batch_localities = var.single_object_validation_batch_localities
+  enable_heap_profiles                      = var.enable_heap_profiles
+  profile_nfs_server                        = var.profile_nfs_server
 }
 
 output "data_share_processor_name" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -297,7 +297,7 @@ resource "kubernetes_cron_job" "workflow_manager" {
                 }
               }
 
-              args = concat([
+              args = [
                 "--aggregation-period", var.aggregation_period,
                 "--grace-period", var.aggregation_grace_period,
                 "--intake-max-age", var.intake_max_age,
@@ -313,7 +313,8 @@ resource "kubernetes_cron_job" "workflow_manager" {
                 "--aggregate-tasks-topic", var.aggregate_queue.topic,
                 "--gcp-project-id", var.use_aws ? "" : data.google_project.project.project_id,
                 "--aws-sns-region", var.use_aws ? var.aws_region : "",
-              ], var.enable_heap_profiles ? ["--memprofile", "/profiles/mem-$(NAMESPACE)-$(POD).pb.gz"] : [])
+                "--memprofile", var.enable_heap_profiles ? "/profiles/mem-$(NAMESPACE)-$(POD).pb.gz" : "",
+              ]
               env {
                 name = "NAMESPACE"
                 value_from {

--- a/terraform/modules/kubernetes_locality/kubernetes_locality.tf
+++ b/terraform/modules/kubernetes_locality/kubernetes_locality.tf
@@ -96,6 +96,13 @@ variable "specific_manifest_templates" {
   type = map(any)
 }
 
+variable "enable_heap_profiles" {
+  type = bool
+}
+
+variable "profile_nfs_server" {
+  type = string
+}
 
 locals {
   iam_entity_name = "${var.environment}-${var.locality}-key-rotator"
@@ -250,7 +257,7 @@ resource "kubernetes_cron_job" "key_rotator" {
                 }
               }
 
-              args = [
+              args = concat([
                 "--prio-environment=${var.environment}",
                 "--kubernetes-namespace=${var.kubernetes_namespace}",
                 "--manifest-bucket-url=${var.manifest_bucket.bucket_url}",
@@ -274,7 +281,30 @@ resource "kubernetes_cron_job" "key_rotator" {
                 "--packet-encryption-key-primary-min-age=${var.packet_encryption_key_rotation_policy.primary_min_age}",
                 "--packet-encryption-key-delete-min-age=${var.packet_encryption_key_rotation_policy.delete_min_age}",
                 "--packet-encryption-key-delete-min-count=${var.packet_encryption_key_rotation_policy.delete_min_count}",
-              ]
+              ], var.enable_heap_profiles ? ["--memprofile", "/profiles/mem-$(NAMESPACE)-$(POD).pb.gz"] : [])
+              env {
+                name = "NAMESPACE"
+                value_from {
+                  field_ref {
+                    field_path = "metadata.namespace"
+                  }
+                }
+              }
+              env {
+                name = "POD"
+                value_from {
+                  field_ref {
+                    field_path = "metadata.name"
+                  }
+                }
+              }
+              dynamic "volume_mount" {
+                for_each = var.profile_nfs_server != null ? [0] : []
+                content {
+                  mount_path = "/profiles"
+                  name       = "profiles"
+                }
+              }
             }
 
             # If we use any other restart policy, then when the job is finally
@@ -288,6 +318,16 @@ resource "kubernetes_cron_job" "key_rotator" {
             restart_policy                  = "Never"
             service_account_name            = module.key_rotator_account.kubernetes_service_account_name
             automount_service_account_token = true
+            dynamic "volume" {
+              for_each = var.profile_nfs_server != null ? [0] : []
+              content {
+                name = "profiles"
+                nfs {
+                  server = var.profile_nfs_server
+                  path   = "/"
+                }
+              }
+            }
           }
         }
       }

--- a/terraform/modules/kubernetes_locality/kubernetes_locality.tf
+++ b/terraform/modules/kubernetes_locality/kubernetes_locality.tf
@@ -257,7 +257,7 @@ resource "kubernetes_cron_job" "key_rotator" {
                 }
               }
 
-              args = concat([
+              args = [
                 "--prio-environment=${var.environment}",
                 "--kubernetes-namespace=${var.kubernetes_namespace}",
                 "--manifest-bucket-url=${var.manifest_bucket.bucket_url}",
@@ -281,7 +281,8 @@ resource "kubernetes_cron_job" "key_rotator" {
                 "--packet-encryption-key-primary-min-age=${var.packet_encryption_key_rotation_policy.primary_min_age}",
                 "--packet-encryption-key-delete-min-age=${var.packet_encryption_key_rotation_policy.delete_min_age}",
                 "--packet-encryption-key-delete-min-count=${var.packet_encryption_key_rotation_policy.delete_min_count}",
-              ], var.enable_heap_profiles ? ["--memprofile", "/profiles/mem-$(NAMESPACE)-$(POD).pb.gz"] : [])
+                "--memprofile", var.enable_heap_profiles ? "/profiles/mem-$(NAMESPACE)-$(POD).pb.gz" : "",
+              ]
               env {
                 name = "NAMESPACE"
                 value_from {

--- a/terraform/modules/nfs_server/nfs_server.tf
+++ b/terraform/modules/nfs_server/nfs_server.tf
@@ -1,0 +1,99 @@
+variable "namespace" {
+  type = string
+}
+
+resource "kubernetes_persistent_volume_claim_v1" "nfs-storage" {
+  metadata {
+    namespace = var.namespace
+    name      = "nfs-storage"
+  }
+  spec {
+    access_modes = ["ReadWriteOnce"]
+    resources {
+      requests = {
+        "storage" = "10Gi"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "nfs-server" {
+  metadata {
+    namespace = var.namespace
+    name      = "nfs-server"
+  }
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = "nfs-server"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "nfs-server"
+        }
+      }
+      spec {
+        container {
+          name  = "nfs-server"
+          image = "k8s.gcr.io/volume-nfs:0.8"
+          port {
+            name           = "nfs"
+            container_port = 2049
+          }
+          port {
+            name           = "mountd"
+            container_port = 20048
+          }
+          port {
+            name           = "rpcbind"
+            container_port = 111
+          }
+          security_context {
+            privileged = true
+          }
+          volume_mount {
+            name       = "storage"
+            mount_path = "/exports"
+          }
+        }
+        volume {
+          name = "storage"
+          persistent_volume_claim {
+            claim_name = "nfs-storage"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "nfs-server" {
+  metadata {
+    namespace = var.namespace
+    name      = "nfs-server"
+  }
+  spec {
+    selector = {
+      "app" = "nfs-server"
+    }
+    port {
+      name = "nfs"
+      port = 2049
+    }
+    port {
+      name = "mountd"
+      port = 20048
+    }
+    port {
+      name = "rpcbind"
+      port = 111
+    }
+  }
+}
+
+output "server" {
+  value = "${kubernetes_service_v1.nfs-server.metadata[0].name}.${kubernetes_service_v1.nfs-server.metadata[0].namespace}.svc.cluster.local"
+}


### PR DESCRIPTION
This adds an option to set up an in-cluster NFS server, backed by a GCE Persistent Disk, and has workflow-manager and key-rotator jobs write out heap profiles to a volume backed by the NFS server. An NFS server is necessary because we need a ReadWriteMany persistent volume, and this is the simplest way to achieve that on GKE. (GCP has a managed NFS offering, but its minimum filesystem size is 1 TiB)

It is intended that this new option will be turned on for a brief time to collect profiles, the profiles will be copied out of the nfs-server pod for later analysis, and the option will be turned off again to tear down NFS-related infrastructure. The added NFS mounts are additional potential failure points for these jobs, so we may as well remove them in normal operation.

This is part of #1757.