### PR TITLE
Set min_node_count=0 in remaining environments

### DIFF
--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -225,7 +225,7 @@ ingestors = {
 }
 cluster_settings = {
   initial_node_count = 4
-  min_node_count     = 1
+  min_node_count     = 0
   max_node_count     = 5
   gcp_machine_type   = "e2-standard-8"
   aws_machine_types  = []

--- a/terraform/variables/stg-us-facil.tfvars
+++ b/terraform/variables/stg-us-facil.tfvars
@@ -63,7 +63,7 @@ ingestors = {
 }
 cluster_settings = {
   initial_node_count = 2
-  min_node_count     = 1
+  min_node_count     = 0
   max_node_count     = 3
   gcp_machine_type   = "e2-standard-2"
   aws_machine_types  = []

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -63,7 +63,7 @@ ingestors = {
 }
 cluster_settings = {
   initial_node_count  = 2
-  min_node_count      = 1
+  min_node_count      = 0
   max_node_count      = 3
   gcp_machine_type    = "e2-standard-2"
   aws_machine_types   = ["t3.medium"]


### PR DESCRIPTION
Now that our GKE clusters have separate spot and standard node pools (in #1703), we can set `min_node_count=0` in GKE environments. (Previously, min_node_count had a different meaning for GKE, and controlled the number of standard VMs per zone) This will allow cluster-autoscaler to shut down up to three spot VMs, depending on workload volume. (I did the same in stg-us-pha as well)