### PR TITLE
Update production to 0.6.47

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -94,9 +94,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-workflow_manager_version = "0.6.46"
-facilitator_version      = "0.6.46"
-key_rotator_version      = "0.6.46"
+workflow_manager_version = "0.6.47"
+facilitator_version      = "0.6.47"
+key_rotator_version      = "0.6.47"
 victorops_routing_key    = "prio-prod-intl"
 
 default_aggregation_period       = "8h"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -234,9 +234,9 @@ is_first                                  = false
 use_aws                                   = false
 default_aggregation_period                = "8h"
 default_aggregation_grace_period          = "4h"
-workflow_manager_version                  = "0.6.46"
-facilitator_version                       = "0.6.46"
-key_rotator_version                       = "0.6.46"
+workflow_manager_version                  = "0.6.47"
+facilitator_version                       = "0.6.47"
+key_rotator_version                       = "0.6.47"
 prometheus_server_persistent_disk_size_gb = 1000
 victorops_routing_key                     = "prio-prod-us"
 


### PR DESCRIPTION
The plans look as expected. prod-us will require `apply-cluster-bootstrap`. Both prod environments will require manual intervention to update the `prometheus-alertmanager-config` secret and re-insert the VictorOps API key.