### PR TITLE
Add EBS CSI addon

### DIFF
--- a/terraform/cluster_bootstrap/main.tf
+++ b/terraform/cluster_bootstrap/main.tf
@@ -56,6 +56,7 @@ variable "cluster_settings" {
     aws_machine_types              = list(string)
     eks_cluster_version            = optional(string)
     eks_vpc_cni_addon_version      = optional(string)
+    eks_ebs_csi_addon_version      = optional(string)
     eks_cluster_autoscaler_version = optional(string)
   })
   description = <<DESCRIPTION
@@ -76,6 +77,9 @@ Settings for the Kubernetes cluster.
     for available versions. Only used in EKS clusters.
   - `eks_vpc_cni_addon_version` is the Amazon VPC CNI add-on version to use. See
     https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html for
+    available versions. Only used in EKS clusters.
+  - `eks_ebs_csi_addon_version` is the Amazon EBS CSI driver add-on version to
+    use. See https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases for
     available versions. Only used in EKS clusters.
   - `eks_cluster_autoscaler_version` is the version of the Kubernetes cluster
     autoscaler to use. The version must match the minor version of Kubernetes.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -300,6 +300,7 @@ variable "cluster_settings" {
     aws_machine_types              = list(string)
     eks_cluster_version            = optional(string)
     eks_vpc_cni_addon_version      = optional(string)
+    eks_ebs_csi_addon_version      = optional(string)
     eks_cluster_autoscaler_version = optional(string)
   })
   description = <<DESCRIPTION
@@ -317,6 +318,9 @@ Settings for the Kubernetes cluster.
     for available versions. Only used in EKS clusters.
   - `eks_vpc_cni_addon_version` is the Amazon VPC CNI add-on version to use. See
     https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html for
+    available versions. Only used in EKS clusters.
+  - `eks_ebs_csi_addon_version` is the Amazon EBS CSI driver add-on version to
+    use. See https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases for
     available versions. Only used in EKS clusters.
   - `eks_cluster_autoscaler_version` is the version of the Kubernetes cluster
     autoscaler to use. The version must match the minor version of Kubernetes.

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -15,6 +15,7 @@ variable "cluster_settings" {
     aws_machine_types              = list(string)
     eks_cluster_version            = optional(string)
     eks_vpc_cni_addon_version      = optional(string)
+    eks_ebs_csi_addon_version      = optional(string)
     eks_cluster_autoscaler_version = optional(string)
   })
 }

--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -88,6 +88,8 @@ cluster_settings = {
   eks_cluster_version = "1.21"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
   eks_vpc_cni_addon_version = "v1.10.1-eksbuild.1"
+  # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases
+  eks_ebs_csi_addon_version = "v1.10.0-eksbuild.1"
   # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.21.2
   eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2"
 }

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -38,6 +38,8 @@ cluster_settings = {
   eks_cluster_version = "1.21"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
   eks_vpc_cni_addon_version = "v1.10.1-eksbuild.1"
+  # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases
+  eks_ebs_csi_addon_version = "v1.10.0-eksbuild.1"
   # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.21.2
   eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2"
 }

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -70,6 +70,8 @@ cluster_settings = {
   eks_cluster_version = "1.21"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
   eks_vpc_cni_addon_version = "v1.10.1-eksbuild.1"
+  # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases
+  eks_ebs_csi_addon_version = "v1.10.0-eksbuild.1"
   # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.21.2
   eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2"
 }


### PR DESCRIPTION
This sets up the EBS CSI addon, which will be required as of EKS version 1.23. It also configures the required IAM role for the addon, following the documentation. As of EKS version 1.23, the in-tree EBS plugin will be removed, and any StorageClass using ` kubernetes.io/aws-ebs` will be migrated to use this addon instead, automatically.

I tested this by creating a StorageClass with provisioner `ebs.csi.aws.com`, a PVC, and a pod, while watching the EBS CSI deployment's logs. The addon successfully created, mounted, unmounted, and deleted the volume.

Note that this change requires `make apply-cluster-bootstrap` to deploy.