### PR TITLE
Fix a clippy warning

### DIFF
--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -153,7 +153,7 @@ pub enum BatchReadError {
     Idl(#[from] IdlError),
     #[error("invalid signature on header with key {0}")]
     InvalidSignature(String),
-    #[error("key identifier {0} not present in key map {:?}")]
+    #[error("key identifier {0} not present in key map {1:?}")]
     UnknownKeyIdentifier(String, Vec<String>),
     #[error("packet file digest in header {0} does not match actual packet file digest {1}")]
     DigestMismatch(String, String),


### PR DESCRIPTION
This fixes a warning that newly appears with a 1.64 Rust toolchain. The derive macro internally uses named arguments, so we were getting the following message.

```
warning: named argument `field__0` is not used by name
   --> src/batch.rs:156:13
    |
156 |       #[error("key identifier {0} not present in key map {:?}")]
    |  _____________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^__-
    | |             |
    | |             this named argument is referred to by position in formatting string
157 | |     UnknownKeyIdentifier(String, Vec<String>),
    | |___- this formatting argument uses named argument `field__0` by position
    |
    = note: `#[warn(named_arguments_used_positionally)]` on by default
help: use the named argument by name to avoid ambiguity
    |
157 | field__0  UnknownKeyIdentifier(String, Vec<String>),
    | ++++++++
```