### PR TITLE
Upgrade to Terraform 1.3

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -73,7 +73,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: ~1.2.0
+        terraform_version: ~1.3.1
     - name: Terraform fmt
       run: terraform fmt --check --recursive
     - name: Terraform init

--- a/terraform/cluster_bootstrap/main.tf
+++ b/terraform/cluster_bootstrap/main.tf
@@ -95,10 +95,7 @@ DESCRIPTION
 terraform {
   backend "gcs" {}
 
-  required_version = ">= 1.1.0"
-
-  # https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes
-  experiments = [module_variable_optional_attrs]
+  required_version = ">= 1.3.1"
 
   required_providers {
     aws = {

--- a/terraform/cluster_bootstrap/modules/eks/eks.tf
+++ b/terraform/cluster_bootstrap/modules/eks/eks.tf
@@ -21,7 +21,7 @@ variable "cluster_settings" {
 }
 
 terraform {
-  experiments = [module_variable_optional_attrs]
+  required_version = ">= 1.3.1"
 }
 
 data "aws_region" "current" {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -354,10 +354,7 @@ variable "enable_heap_profiles" {
 terraform {
   backend "gcs" {}
 
-  required_version = ">= 1.2.0"
-
-  # https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes
-  experiments = [module_variable_optional_attrs]
+  required_version = ">= 1.3.1"
 
   required_providers {
     aws = {

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -21,7 +21,7 @@ variable "cluster_settings" {
 }
 
 terraform {
-  experiments = [module_variable_optional_attrs]
+  required_version = ">= 1.3.1"
 }
 
 # This cluster role binding references the built-in cluster role "view" and


### PR DESCRIPTION
This handles the upgrade to Terraform 1.3, which is a breaking change for us as we were relying on an experiment that has now been removed. We did not use the `defaults` function at all, so we do not have to make any syntax changes to adapt to the stabilized `optional()` modifier.

We are affected by a [bug in 1.3.0 related to checks on resources inside modules](https://github.com/hashicorp/terraform/issues/31846), so I have speculatively set the minimum version to 1.3.1. This upgrade is blocked on a fix landing and being released.