### PR TITLE
Raise limits on open PRs from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/facilitator"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
   - package-ecosystem: "docker"
     directory: "/facilitator"
     schedule:
@@ -13,6 +14,7 @@ updates:
     directory: "/key-rotator"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
   - package-ecosystem: "docker"
     directory: "/key-rotator"
     schedule:
@@ -21,14 +23,17 @@ updates:
     directory: "/terraform"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
   - package-ecosystem: "terraform"
     directory: "/terraform/cluster_bootstrap"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
   - package-ecosystem: "gomod"
     directory: "/workflow-manager"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
   - package-ecosystem: "docker"
     directory: "/workflow-manager"
     schedule:


### PR DESCRIPTION
This raises the limits on open Dependabot PRs for Go, Cargo, and Terraform. Previously, each run was limited to five open PRs by default. As we only have Dependabot run weekly, we should raise this so it can open more PRs without manual intervention (i.e., navigating [here](https://github.com/divviup/prio-server/network/updates) and re-running it).

I noticed that we did hit the limit for Go this week, and I infer we probably hit the limit in one of our Terraform modules last week. The error message was as follows.

```
Dependabot cannot open any more pull requests

The open pull request limit has been exceeded. The current limit is: 5.
```