### PR TITLE
Add declarations, silence unused variable warnings

### DIFF
--- a/terraform/cluster_bootstrap/unused_variables.tf
+++ b/terraform/cluster_bootstrap/unused_variables.tf
@@ -1,0 +1,169 @@
+# The following variables are unused in the cluster_bootstrap module, but are
+# used in the parent directory's module. They are declared here to avoid
+# "undeclared variable" warnings.
+
+variable "pure_gcp" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "localities" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "ingestors" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "manifest_domain" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "managed_dns_zone" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "test_peer_environment" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "is_first" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "intake_max_age" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "default_aggregation_period" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "default_aggregation_grace_period" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "default_peer_share_processor_manifest_base_url" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "default_portal_server_manifest_base_url" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "container_registry" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "workflow_manager_image" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "workflow_manager_version" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "facilitator_image" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "facilitator_version" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "key_rotator_image" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "key_rotator_version" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "prometheus_server_persistent_disk_size_gb" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "victorops_routing_key" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "batch_signing_key_rotation_policy" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "packet_encryption_key_rotation_policy" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "key_rotator_schedule" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "enable_key_rotation_localities" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "prometheus_helm_chart_version" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "grafana_helm_chart_version" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "cloudwatch_exporter_helm_chart_version" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "stackdriver_exporter_helm_chart_version" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "single_object_validation_batch_localities" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "state_bucket" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "role_permissions_boundary_policy_arn" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}
+variable "enable_heap_profiles" {
+  type        = any
+  default     = null
+  description = "This variable is not used in the cluster_bootstrap module"
+}


### PR DESCRIPTION
This adds stub declarations for variables that are used in the main Terraform module, but not the cluster_bootstrap module. Between this and the recent Terraform 1.3 upgrade, I no longer get any warnings when planning any environment.