### PR TITLE
Don't use postconditions on `data.http` resources

### DIFF
--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -179,33 +179,15 @@ data "external" "global_manifest_http_status" {
 data "http" "ingestor_global_manifest" {
   count = local.ingestor_global_manifest_exists ? 1 : 0
   url   = "https://${var.ingestor_manifest_base_url}/global-manifest.json"
-  lifecycle {
-    postcondition {
-      condition     = self.status_code == 200
-      error_message = "Error fetching global manifest a second time"
-    }
-  }
 }
 
 data "http" "ingestor_specific_manifest" {
   count = local.ingestor_global_manifest_exists ? 0 : 1
   url   = "https://${var.ingestor_manifest_base_url}/${var.data_share_processor_name}-manifest.json"
-  lifecycle {
-    postcondition {
-      condition     = self.status_code == 200
-      error_message = "Error fetching both global manifest and ingestor-specific manifest"
-    }
-  }
 }
 
 data "http" "peer_share_processor_global_manifest" {
   url = "https://${var.peer_share_processor_manifest_base_url}/global-manifest.json"
-  lifecycle {
-    postcondition {
-      condition     = self.status_code == 200
-      error_message = "Error fetching peer data share processor's global manifest"
-    }
-  }
 }
 
 locals {


### PR DESCRIPTION
Putting a `lifecycle.postcondition` on a `data.http` seems to force Terraform to defer reading that resource until the apply phase. This means that any resource that depends in turn on the `data.http` can't be planned, which leaves us unable to deploy new localities.

This commit deletes the `lifecycle` blocks, which lets us `plan` and hopefully `apply` again. We should still fail obviously if some JSON manifest can't be fetched, because parsing the JSON or accessing some field of the manifest will fail.