### PR TITLE
Reduce creation minimum age to 1w temporarily.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -234,7 +234,7 @@ variable "packet_encryption_key_rotation_policy" {
     delete_min_count = number
   })
   default = {
-    create_min_age   = "6480h" // 6480 hours = 9 months (w/ 30-day months, 24-hour days)
+    create_min_age   = "168h" // 168 hours = 1 week (w/ 24-hour days)  // TODO: revert to 6480 hours = 9 months (w/ 30-day months, 24-hour days)
     primary_min_age  = "0"
     delete_min_age   = "9360h" // 9360 hours = 13 months (w/ 30-day months, 24-hour days)
     delete_min_count = 2


### PR DESCRIPTION
This is intended to induce a key rotation. Once the key rotates once, we will revert this change.

The current situation: the key versions are (`old`, `bad`). Clients are submitting reports with both `old` & `bad` key versions. The `bad` key version cannot be used by Apple due to a technical issue. We cannot immediately delete either key version as we expect to receive reports from both. Our goal is to introduce a new key version without deleting either existing key version.

Overall plan:
* Submit this PR.
* Allow the key rotator to run. Since `bad` is more than 1w old, the key rotator will introduce a new key version `new`. As `old` was generated on 1/3 (i.e. 9 months ago), and `delete_min_age` is 13 months, no key versions will be deleted.
* Revert this PR within a week of the previous step. This will avoid the key rotator from introducing additional new versions.
* Continue operating with (`old`, `bad`, `new`) for the time being. On approximately 2/3/2023, the key rotator will remove `old` & we will return to operating with only two key versions.