### PR TITLE
GHA: Replace ::set-output with file redirection

### DIFF
--- a/.github/workflows/push-docker-image-main.yml
+++ b/.github/workflows/push-docker-image-main.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get hash
       id: get_hash
-      run: echo ::set-output name=HASH::$(git rev-parse --short HEAD)
+      run: echo HASH=$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
     - name: Set up Docker build
       uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get hash
       id: get_hash
-      run: echo ::set-output name=HASH::$(git rev-parse --short HEAD)
+      run: echo HASH=$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
     - name: Set up Docker build
       uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get hash
       id: get_hash
-      run: echo ::set-output name=HASH::$(git rev-parse --short HEAD)
+      run: echo HASH=$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
     - name: Set up Docker build
       uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub

--- a/.github/workflows/push-docker-image-release.yml
+++ b/.github/workflows/push-docker-image-release.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
     - name: Set up Docker build
       uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
     - name: Set up Docker build
       uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
     - name: Set up Docker build
       uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub


### PR DESCRIPTION
GitHub is now displaying a warning that [::set-output is deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This updates our release publishing workflows to use the recommended replacement mechanism, "environment files".