### PR TITLE
Wait 23h before promoting packet encryption key to primary.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -235,7 +235,7 @@ variable "packet_encryption_key_rotation_policy" {
   })
   default = {
     create_min_age   = "168h" // 168 hours = 1 week (w/ 24-hour days)  // TODO: revert to 6480 hours = 9 months (w/ 30-day months, 24-hour days)
-    primary_min_age  = "0"
+    primary_min_age  = "23h"
     delete_min_age   = "9360h" // 9360 hours = 13 months (w/ 30-day months, 24-hour days)
     delete_min_count = 2
   }


### PR DESCRIPTION
Previously, we would promote a new packet encryption key to primary immediately, causing it to be advertised in our manifest as soon as it was created. Since our own jobs notice key updates on a 1h cadence, there was a small window of time where we were advertising a key that was not accepted by our jobs. We reasoned that it was very unlikely that end-user devices would receive a key update in less than one hour -- but this appears to be incorrect, based on our latest key rotation, in which a few devices appear to have started using the new key within 1h of it being introduced (leading to minor data loss).