### PR TITLE
Update staging to 0.6.69

### DIFF
--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -46,9 +46,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-workflow_manager_version = "0.6.68"
-facilitator_version      = "0.6.68"
-key_rotator_version      = "0.6.68"
+workflow_manager_version = "0.6.69"
+facilitator_version      = "0.6.69"
+key_rotator_version      = "0.6.69"
 victorops_routing_key    = "prio-staging"
 
 default_aggregation_period       = "30m"

--- a/terraform/variables/stg-us-facil.tfvars
+++ b/terraform/variables/stg-us-facil.tfvars
@@ -74,9 +74,9 @@ test_peer_environment = {
 }
 is_first                 = false
 use_aws                  = false
-workflow_manager_version = "0.6.68"
-facilitator_version      = "0.6.68"
-key_rotator_version      = "0.6.68"
+workflow_manager_version = "0.6.69"
+facilitator_version      = "0.6.69"
+key_rotator_version      = "0.6.69"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -81,9 +81,9 @@ test_peer_environment = {
 }
 is_first                 = true
 use_aws                  = true
-workflow_manager_version = "0.6.68"
-facilitator_version      = "0.6.68"
-key_rotator_version      = "0.6.68"
+workflow_manager_version = "0.6.69"
+facilitator_version      = "0.6.69"
+key_rotator_version      = "0.6.69"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"


### PR DESCRIPTION
These plans look as expected, with just `--packet-encryption-key-primary-min-age` and container image version updates.