### PR TITLE
Clippy fixes - Rust 1.65

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        default: true
     - name: Lint
       run: cargo fmt --message-format human -- --check
     - name: clippy

--- a/facilitator/Dockerfile
+++ b/facilitator/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.64.0-alpine as builder
+FROM rust:1.65.0-alpine as builder
 
 RUN apk add libc-dev && apk update
 

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -821,7 +821,7 @@ mod tests {
         };
         roundtrip_batch(
             &*INGESTION_HEADER,
-            &*INGESTION_DATA_SHARE_PACKETS,
+            &INGESTION_DATA_SHARE_PACKETS,
             base_path,
             &filenames,
             &batch_writer,
@@ -916,7 +916,7 @@ mod tests {
         };
         roundtrip_batch(
             &*VALIDATION_HEADER,
-            &*VALIDATION_PACKETS,
+            &VALIDATION_PACKETS,
             base_path,
             &filenames,
             &batch_writer,
@@ -1024,7 +1024,7 @@ mod tests {
         };
         roundtrip_batch(
             &*SUM_PART,
-            &*INVALID_PACKETS,
+            &INVALID_PACKETS,
             batch_path,
             &filenames,
             &batch_writer,

--- a/facilitator/src/gcp_oauth.rs
+++ b/facilitator/src/gcp_oauth.rs
@@ -200,6 +200,7 @@ pub enum GcpAuthError {
 /// used either to authenticate to GCP services or to obtain a further service
 /// account access token from GCP IAM.
 trait ProvideDefaultAccessToken: Debug + DynClone + Send + Sync {
+    #[allow(clippy::result_large_err)]
     fn default_access_token(&self) -> Result<Response, GcpAuthError>;
 }
 
@@ -581,6 +582,7 @@ impl GcpAccessTokenProvider {
     /// is valid. Otherwise obtains and returns a new one.
     /// The returned value is an owned reference because the token owned by this
     /// struct could change while the caller is still holding the returned token
+    #[allow(clippy::result_large_err)]
     fn ensure_default_access_token(&self) -> Result<String, GcpAuthError> {
         debug!(self.logger, "obtaining read lock on default access token");
         if let Some(token) = &*self.default_access_token.read().unwrap() {
@@ -623,6 +625,7 @@ impl GcpAccessTokenProvider {
 
     /// Returns the current access token for the impersonated service account,
     /// if it is valid. Otherwise obtains and returns a new one.
+    #[allow(clippy::result_large_err)]
     fn ensure_impersonated_service_account_access_token(
         &self,
         service_account_to_impersonate: &str,

--- a/facilitator/src/http.rs
+++ b/facilitator/src/http.rs
@@ -84,6 +84,7 @@ impl RetryingAgent {
     /// `::send_string` to get retries.
     /// Returns an Error if the AccessTokenProvider returns an error when
     /// supplying the request with an access token.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn prepare_request(
         &self,
         parameters: RequestParameters,
@@ -120,6 +121,7 @@ impl RetryingAgent {
     }
 
     /// Send the provided request with the provided JSON body.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn send_json_request(
         &self,
         logger: &Logger,
@@ -135,6 +137,7 @@ impl RetryingAgent {
     }
 
     /// Send the provided request with the provided bytes as the body.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn send_bytes(
         &self,
         logger: &Logger,
@@ -150,6 +153,7 @@ impl RetryingAgent {
     }
 
     /// Send the provided data as a form encoded body.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn send_form(
         &self,
         logger: &Logger,
@@ -165,6 +169,7 @@ impl RetryingAgent {
     }
 
     /// Send the provided request with no body.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn call(
         &self,
         logger: &Logger,
@@ -179,6 +184,7 @@ impl RetryingAgent {
     }
 
     /// Send the provided request with no body, and read the response into a string.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn fetch_to_string(
         &self,
         logger: &Logger,
@@ -197,6 +203,7 @@ impl RetryingAgent {
 
     /// Perform some operation `op`, logging metrics on the request status and
     /// latency.
+    #[allow(clippy::result_large_err)]
     fn do_request_with_metrics<F>(
         &self,
         endpoint: &'static str,
@@ -225,6 +232,7 @@ impl RetryingAgent {
 }
 
 /// Defines a behavior responsible for produing bearer authorization tokens
+#[allow(clippy::result_large_err)]
 pub(crate) trait AccessTokenProvider: Debug + DynClone + Send + Sync {
     /// Returns a valid bearer authroization token
     fn ensure_access_token(&self) -> Result<String, GcpAuthError>;

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -140,7 +140,7 @@ impl BatchSignature {
     /// Reads and parses one BatchSignature from the provided std::io::Read
     /// instance.
     pub fn read<R: Read>(reader: R) -> Result<BatchSignature, IdlError> {
-        let mut reader = Reader::with_schema(*BATCH_SIGNATURE_SCHEMA, reader)
+        let mut reader = Reader::with_schema(&BATCH_SIGNATURE_SCHEMA, reader)
             .map_err(|e| IdlError::Avro(e, "reading avro header"))?;
 
         // We expect exactly one record and for it to be an ingestion signature
@@ -161,7 +161,7 @@ impl BatchSignature {
     /// Serializes this signature into Avro format and writes it to the provided
     /// std::io::Write instance.
     pub fn write<W: Write>(&self, writer: &mut W) -> Result<(), IdlError> {
-        let mut writer = Writer::new(*BATCH_SIGNATURE_SCHEMA, writer);
+        let mut writer = Writer::new(&BATCH_SIGNATURE_SCHEMA, writer);
         writer
             .append(self.clone())
             .map_err(|e| IdlError::Avro(e, "writing"))?;
@@ -228,7 +228,7 @@ impl From<BatchSignature> for Value {
         // a `Schema::Record` variant", which shouldn't ever happen, so
         // panic for debugging
         // https://docs.rs/avro-rs/0.11.0/avro_rs/types/struct.Record.html#method.new
-        let mut record = Record::new(*BATCH_SIGNATURE_SCHEMA)
+        let mut record = Record::new(&BATCH_SIGNATURE_SCHEMA)
             .expect("Unable to create record from batch signature schema");
 
         record.put(
@@ -304,7 +304,7 @@ impl Header for IngestionHeader {
     }
 
     fn read<R: Read>(reader: R) -> Result<IngestionHeader, IdlError> {
-        let mut reader = Reader::with_schema(*INGESTION_HEADER_SCHEMA, reader)
+        let mut reader = Reader::with_schema(&INGESTION_HEADER_SCHEMA, reader)
             .map_err(|e| IdlError::Avro(e, "reading avro header"))?;
 
         // We expect exactly one record in the reader and for it to be an ingestion header
@@ -397,7 +397,7 @@ impl Header for IngestionHeader {
     }
 
     fn write<W: Write>(&self, writer: &mut W) -> Result<(), IdlError> {
-        let mut writer = Writer::new(*INGESTION_HEADER_SCHEMA, writer);
+        let mut writer = Writer::new(&INGESTION_HEADER_SCHEMA, writer);
 
         // Ideally we would just do `writer.append_ser(self)` to use Serde serialization to write
         // the record but there seems to be some problem with serializing UUIDs, so we have to
@@ -460,7 +460,7 @@ pub struct IngestionDataSharePacket {
 
 impl Packet for IngestionDataSharePacket {
     fn schema() -> &'static Schema {
-        *INGESTION_DATA_SHARE_PACKET_SCHEMA
+        &INGESTION_DATA_SHARE_PACKET_SCHEMA
     }
 
     fn write<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), IdlError> {
@@ -640,7 +640,7 @@ impl Header for ValidationHeader {
     }
 
     fn read<R: Read>(reader: R) -> Result<ValidationHeader, IdlError> {
-        let mut reader = Reader::with_schema(*VALIDATION_HEADER_SCHEMA, reader)
+        let mut reader = Reader::with_schema(&VALIDATION_HEADER_SCHEMA, reader)
             .map_err(|e| IdlError::Avro(e, "reading avro header"))?;
 
         // We expect exactly one record in the reader and for it to be an ingestion header
@@ -725,7 +725,7 @@ impl Header for ValidationHeader {
     }
 
     fn write<W: Write>(&self, writer: &mut W) -> Result<(), IdlError> {
-        let mut writer = Writer::new(*VALIDATION_HEADER_SCHEMA, writer);
+        let mut writer = Writer::new(&VALIDATION_HEADER_SCHEMA, writer);
 
         let mut record = match Record::new(writer.schema()) {
             Some(r) => r,
@@ -771,7 +771,7 @@ pub struct ValidationPacket {
 
 impl Packet for ValidationPacket {
     fn schema() -> &'static Schema {
-        *VALIDATION_PACKET_SCHEMA
+        &VALIDATION_PACKET_SCHEMA
     }
 
     fn write<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), IdlError> {
@@ -856,7 +856,7 @@ impl Header for SumPart {
     }
 
     fn read<R: Read>(reader: R) -> Result<SumPart, IdlError> {
-        let mut reader = Reader::with_schema(*SUM_PART_SCHEMA, reader)
+        let mut reader = Reader::with_schema(&SUM_PART_SCHEMA, reader)
             .map_err(|e| IdlError::Avro(e, "reading avro header"))?;
 
         // We expect exactly one record in the reader and for it to be a sum
@@ -989,7 +989,7 @@ impl Header for SumPart {
     }
 
     fn write<W: Write>(&self, writer: &mut W) -> Result<(), IdlError> {
-        let mut writer = Writer::new(*SUM_PART_SCHEMA, writer);
+        let mut writer = Writer::new(&SUM_PART_SCHEMA, writer);
 
         // Ideally we would just do `writer.append_ser(self)` to use Serde serialization to write
         // the record but there seems to be some problem with serializing UUIDs, so we have to
@@ -1055,7 +1055,7 @@ pub struct InvalidPacket {
 
 impl Packet for InvalidPacket {
     fn schema() -> &'static Schema {
-        *INVALID_PACKET_SCHEMA
+        &INVALID_PACKET_SCHEMA
     }
 
     fn write<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), IdlError> {

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -564,7 +564,7 @@ fn public_key_from_pem(pem_key: &str) -> Result<UnparsedPublicKey<Vec<u8>>> {
     if pem_key.is_empty() {
         return Err(anyhow!("empty PEM input"));
     }
-    let pem = pem::parse(&pem_key).context(format!("failed to parse key as PEM: {}", pem_key))?;
+    let pem = pem::parse(pem_key).context(format!("failed to parse key as PEM: {}", pem_key))?;
     const WANT_PEM_TAG: &str = "PUBLIC KEY";
     if pem.tag != WANT_PEM_TAG {
         return Err(anyhow!(

--- a/facilitator/src/transport.rs
+++ b/facilitator/src/transport.rs
@@ -19,6 +19,7 @@ pub use gcs::GcsTransport;
 pub use local::LocalFileTransport;
 
 /// Common error type for I/O over any batch transport.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum TransportError {
     #[error("object {0} not found: {1}")]

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -259,6 +259,7 @@ impl StreamingTransferWriter {
     /// the name of the GCS bucket. Object is the full name of the object being
     /// uploaded, which may contain path separators or file extensions.
     /// oauth_token is used to initiate the initial resumable upload request.
+    #[allow(clippy::result_large_err)]
     fn new(
         bucket: String,
         object: String,
@@ -279,6 +280,7 @@ impl StreamingTransferWriter {
         )
     }
 
+    #[allow(clippy::result_large_err)]
     fn new_with_api_url(
         bucket: String,
         object: String,
@@ -332,6 +334,7 @@ impl StreamingTransferWriter {
         })
     }
 
+    #[allow(clippy::result_large_err)]
     fn upload_chunk(&mut self, last_chunk: bool) -> Result<(), GcsError> {
         if self.buffer.is_empty() {
             return Ok(());

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -416,10 +416,10 @@ impl TransportWriter for MultipartUploadWriter {
                     })
                     .map(|rslt| {
                         if let Ok(output) = rslt {
-                            if output.location == None
-                                && output.e_tag == None
-                                && output.bucket == None
-                                && output.key == None
+                            if output.location.is_none()
+                                && output.e_tag.is_none()
+                                && output.bucket.is_none()
+                                && output.key.is_none()
                             {
                                 // Due to an oddity in S3's CompleteMultipartUpload API, some
                                 // failed uploads can cause complete_multipart_upload to return


### PR DESCRIPTION
This fixes and ignores various new Clippy warnings. `clippy::large_enum_variant` and `clippy::result_large_err` are ignored instead of adding boxing of the various errors.