### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -174,7 +174,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3.3.0
       with:
         working-directory: key-rotator
-        version: "v1.45.2"
+        version: "v1.50.1"
         args: "--config ../.golangci.yml --timeout 10m"
 
   workflow-manager-golangci-lint:
@@ -189,5 +189,5 @@ jobs:
       uses: golangci/golangci-lint-action@v3.3.0
       with:
         working-directory: workflow-manager
-        version: "v1.45.2"
+        version: "v1.50.1"
         args: "--config ../.golangci.yml --timeout 10m"

--- a/key-rotator/go.mod
+++ b/key-rotator/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/rs/zerolog v1.28.0
 	golang.org/x/sync v0.1.0
-	google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c
 	google.golang.org/grpc v1.50.1
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3
@@ -73,6 +72,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.102.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/key-rotator/key/key.go
+++ b/key-rotator/key/key.go
@@ -201,14 +201,14 @@ func (cfg RotationConfig) Validate() error {
 // config, returning a new key (or the same key, if no rotation is necessary).
 //
 // Keys are rotated according to the following policy:
-//  * If no key versions exist, or if the youngest key version is older than
-//    `create_min_age`, create a new key version.
-//  * While there are more than `delete_min_key_count` keys, and the oldest key
-//    version is older than `delete_min_age`, delete the oldest key version.
-//  * Determine the current primary version:
-//    * If there is a key version not younger than `primary_min_age`, select
-//      the youngest such key version as primary.
-//    * Otherwise, select the oldest key version as primary.
+//   - If no key versions exist, or if the youngest key version is older than
+//     `create_min_age`, create a new key version.
+//   - While there are more than `delete_min_key_count` keys, and the oldest key
+//     version is older than `delete_min_age`, delete the oldest key version.
+//   - Determine the current primary version:
+//   - If there is a key version not younger than `primary_min_age`, select
+//     the youngest such key version as primary.
+//   - Otherwise, select the oldest key version as primary.
 //
 // The returned key is guaranteed to include at least one version.
 func (k Key) Rotate(now time.Time, cfg RotationConfig) (Key, error) {

--- a/key-rotator/storage/key_gcp.go
+++ b/key-rotator/storage/key_gcp.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	smpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/rs/zerolog/log"
-	smpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/key-rotator/storage/key_test.go
+++ b/key-rotator/storage/key_test.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	smpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gax-go/v2"
-	smpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	k8sapi "k8s.io/api/core/v1"

--- a/workflow-manager/time/time.go
+++ b/workflow-manager/time/time.go
@@ -89,14 +89,15 @@ func (i Interval) String() string {
 // TimestampPrefixes returns a list of timestamps, truncated to the hour,
 // representing hours included in the Interval. For example, if the Interval
 // were 2021/01/01/00/00 - 2021/01/01/06/00, this would return
-// []Timestamp {
-//      "2021/01/01/00",
-//      "2021/01/01/01",
-//      "2021/01/01/02",
-//      "2021/01/01/03",
-//      "2021/01/01/04",
-//      "2021/01/01/05",
-// }
+//
+//	[]Timestamp {
+//	     "2021/01/01/00",
+//	     "2021/01/01/01",
+//	     "2021/01/01/02",
+//	     "2021/01/01/03",
+//	     "2021/01/01/04",
+//	     "2021/01/01/05",
+//	}
 //
 // If the interval were 2021/01/01/00/00 - 2021/01/01/00/30 (less than one
 // hour), this would return

--- a/workflow-manager/tokenfetcher/tokenfetcher.go
+++ b/workflow-manager/tokenfetcher/tokenfetcher.go
@@ -2,7 +2,7 @@ package tokenfetcher
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -30,7 +30,7 @@ func (tf TokenFetcher) FetchToken(credentials.Context) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetching %s: %w", url, err)
 	}
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading body of %s: %w", url, err)
 	}


### PR DESCRIPTION
This updates golangci-lint to the latest version, reformats some comments, and swaps out some deprecated items for their non-deprecated aliases.