### PR TITLE
Upgrade to AWS for Fluent Bit 2.28.3

### DIFF
--- a/terraform/modules/eks/log.tf
+++ b/terraform/modules/eks/log.tf
@@ -172,7 +172,7 @@ resource "kubernetes_daemonset" "fluent_bit" {
 
         container {
           name              = "fluent-bit"
-          image             = "amazon/aws-for-fluent-bit:2.25.0"
+          image             = "amazon/aws-for-fluent-bit:2.28.3"
           image_pull_policy = "Always"
 
           env {


### PR DESCRIPTION
This upgrades the version of AWS for Fluent Bit we use. The intervening release notes for both [this distribution](https://github.com/aws/aws-for-fluent-bit/releases) and [upstream Fluent Bit](https://fluentbit.io/announcements/older-versions/) look like they shouldn't cause problems.