### PR TITLE
prod-intl: Enable key rotation

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -119,6 +119,8 @@ default_aggregation_grace_period = "4h"
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-enpa-g-prod-manifests"
 default_portal_server_manifest_base_url        = "manifest.global.enpa-pha.io"
 
+enable_key_rotation_localities = ["*"]
+
 prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"


### PR DESCRIPTION
This PR enables key rotation in the prod-intl localities.

I'm staging this as a draft PR for the moment. As previously discussed, we would prefer to roll this out in coordination with the peer servers. We will need to deploy this within a week and a half to beat a certificate expiration deadline.