### PR TITLE
Gracefully exit upon SIGTERM

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -759,6 +759,7 @@ dependencies = [
  "serde_json",
  "serde_test",
  "sha2 0.10.6",
+ "signal-hook",
  "slog",
  "slog-async",
  "slog-json",
@@ -2440,10 +2441,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.3.0"
+name = "signal-hook"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -39,6 +39,7 @@ rusoto_sns = { version = "^0.48", default_features = false, features = ["rustls"
 rusoto_sqs = { version = "^0.48", default_features = false, features = ["rustls"] }
 rusoto_sts = { version = "^0.48", default_features = false, features = ["rustls"] }
 sha2 = "0.10"
+signal-hook = "0.3.14"
 slog = { version = "2.7.0", features = ["max_level_trace"] }
 slog-async = "2.7.0"
 slog-json = "2.6.1"


### PR DESCRIPTION
This registers a SIGTERM hook in each of the worker subcommands, and checks for a signal at the top of the main loop. Previously, SIGTERM signals had no effect, as the process is running as uid 0. Containers would be killed 15 seconds later with a SIGKILL. This change will make it much less likely that intake batch workers will be killed while they are processing a queue message. In turn, this means those messages won't have to wait for a timeout before being redelivered and our queues will clear out faster, preventing `intake_task_queue_growth` false alarms.

This closes #2229.