### PR TITLE
terraform: update CRD specification for k8s 1.22

### DIFF
--- a/terraform/modules/custom_metrics/custom_metrics.tf
+++ b/terraform/modules/custom_metrics/custom_metrics.tf
@@ -307,7 +307,7 @@ resource "kubernetes_cluster_role_binding" "custom_metrics_adapter_resource_read
 resource "kubernetes_manifest" "external_metrics_crd" {
   count = var.use_aws ? 1 : 0
   manifest = {
-    apiVersion = "apiextensions.k8s.io/v1beta1"
+    apiVersion = "apiextensions.k8s.io/v1"
     kind       = "CustomResourceDefinition"
 
     metadata = {
@@ -315,14 +315,18 @@ resource "kubernetes_manifest" "external_metrics_crd" {
     }
 
     spec = {
-      group   = "metrics.aws"
-      version = "v1alpha1"
+      group = "metrics.aws"
       names = {
         kind     = "ExternalMetric"
         plural   = "externalmetrics"
         singular = "externalmetric"
       }
       scope = "Namespaced"
+      versions = [{
+        name    = "v1alpha1"
+        served  = true
+        storage = true
+      }]
     }
   }
 }


### PR DESCRIPTION
We're migrating our EKS clusters to Kubernetes 1.22 (#2249). That release of Kubernetes promoted the `CustomResourceDefinition` resource from `apiextensions.k8s.io/v1beta1` to plain `v1`. That also changes the schema for CRDs so that they have a `versions` array instead of a single `version` ([k8s docs][1]). We update our declaration of the `kubernetes_manifest` resource to match.

[1]: https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/#CustomResourceDefinitionSpec