### PR TITLE
Clippy fixes

### DIFF
--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -895,7 +895,7 @@ mod tests {
             END_TIMESTAMP.format(DATE_FORMAT),
             BATCH_ID.to_hyphenated()
         );
-        let idx = if is_first { 0 } else { 1 };
+        let idx = i32::from(!is_first);
         let filenames = if single_object_write {
             vec![format!("validity_{}.sig", idx)]
         } else {
@@ -1003,7 +1003,7 @@ mod tests {
             START_TIMESTAMP.format(AGGREGATION_DATE_FORMAT),
             END_TIMESTAMP.format(AGGREGATION_DATE_FORMAT)
         );
-        let idx = if is_first { 0 } else { 1 };
+        let idx = i32::from(!is_first);
         let filenames = if single_object_write {
             vec![format!("sum_{}.sig", idx)]
         } else {

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -56,7 +56,7 @@ impl Batch<ValidationHeader, ValidationPacket> {
             aggregation_name,
             batch_id,
             date,
-            &format!("validity_{}", if is_first { 0 } else { 1 }),
+            &format!("validity_{}", i32::from(!is_first)),
         )
     }
 }
@@ -77,16 +77,12 @@ impl Batch<SumPart, InvalidPacket> {
             aggregation_start.format(AGGREGATION_DATE_FORMAT),
             aggregation_end.format(AGGREGATION_DATE_FORMAT)
         );
-        let filename = format!("sum_{}", if is_first { 0 } else { 1 });
+        let filename = format!("sum_{}", i32::from(!is_first));
 
         Self {
             header_path: format!("{}.{}", batch_path, filename),
             signature_path: format!("{}.{}.sig", batch_path, filename),
-            packet_file_path: format!(
-                "{}.invalid_uuid_{}.avro",
-                batch_path,
-                if is_first { 0 } else { 1 }
-            ),
+            packet_file_path: format!("{}.invalid_uuid_{}.avro", batch_path, i32::from(!is_first)),
 
             phantom_header: PhantomData,
             phantom_packet: PhantomData,

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -323,7 +323,7 @@ impl MultipartUploadWriter {
                     bucket: self.bucket.to_string(),
                     key: self.key.to_string(),
                     upload_id: self.upload_id.clone(),
-                    part_number: part_number as i64,
+                    part_number,
                     body: Some(body.clone().into()),
                     ..Default::default()
                 })


### PR DESCRIPTION
This fixes some Clippy warnings in Rust 1.66.