### PR TITLE
Update to AWS for Fluent Bit 2.29.0

### DIFF
--- a/terraform/modules/eks/log.tf
+++ b/terraform/modules/eks/log.tf
@@ -172,7 +172,7 @@ resource "kubernetes_daemonset" "fluent_bit" {
 
         container {
           name              = "fluent-bit"
-          image             = "amazon/aws-for-fluent-bit:2.28.3"
+          image             = "amazon/aws-for-fluent-bit:2.29.0"
           image_pull_policy = "Always"
 
           env {


### PR DESCRIPTION
The [release notes](https://github.com/aws/aws-for-fluent-bit/releases/tag/v2.29.0) for this version mention that the CloudWatch plugin has been moved to a better-supported networking stack inside Fluent Bit, and that this should resolve hangs and segfaults. We've noticed SIGSEGVs shortly after CloudWatch API control plane API calls over the past few months, and this should hopefully resolve that.