### PR TITLE
Bump cloudwatch-exporter, enable ListMetrics cache

### DIFF
--- a/terraform/modules/monitoring/monitoring.tf
+++ b/terraform/modules/monitoring/monitoring.tf
@@ -502,9 +502,10 @@ resource "helm_release" "cloudwatch_exporter" {
       metrics = [
         # SQS queue depth
         {
-          aws_namespace   = "AWS/SQS"
-          aws_metric_name = "ApproximateNumberOfMessagesVisible"
-          aws_dimensions  = ["QueueName"]
+          aws_namespace          = "AWS/SQS"
+          aws_metric_name        = "ApproximateNumberOfMessagesVisible"
+          aws_dimensions         = ["QueueName"]
+          list_metrics_cache_ttl = 600 # 10 minutes
         }
       ]
     })

--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -133,7 +133,7 @@ packet_encryption_key_rotation_policy = {
 
 prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
-cloudwatch_exporter_helm_chart_version  = "0.17.2"
+cloudwatch_exporter_helm_chart_version  = "0.22.0"
 stackdriver_exporter_helm_chart_version = "2.2.0"
 
 allowed_aws_account_ids = ["718214359651"]

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -247,7 +247,7 @@ enable_key_rotation_localities = ["*"]
 
 prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
-cloudwatch_exporter_helm_chart_version  = "0.17.2"
+cloudwatch_exporter_helm_chart_version  = "0.22.0"
 stackdriver_exporter_helm_chart_version = "2.2.0"
 
 allowed_aws_account_ids = ["338276578713"]

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -59,7 +59,7 @@ default_portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"
 
 prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
-cloudwatch_exporter_helm_chart_version  = "0.17.2"
+cloudwatch_exporter_helm_chart_version  = "0.22.0"
 stackdriver_exporter_helm_chart_version = "2.2.0"
 
 allowed_aws_account_ids = ["024759592502"]

--- a/terraform/variables/stg-us-facil.tfvars
+++ b/terraform/variables/stg-us-facil.tfvars
@@ -98,7 +98,7 @@ single_object_validation_batch_localities = ["gondor", "narnia"]
 
 prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
-cloudwatch_exporter_helm_chart_version  = "0.17.2"
+cloudwatch_exporter_helm_chart_version  = "0.22.0"
 stackdriver_exporter_helm_chart_version = "2.2.0"
 
 allowed_aws_account_ids = ["183375168988"]

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -105,7 +105,7 @@ single_object_validation_batch_localities = ["gondor", "narnia"]
 
 prometheus_helm_chart_version           = "15.9.0"
 grafana_helm_chart_version              = "6.20.5"
-cloudwatch_exporter_helm_chart_version  = "0.17.2"
+cloudwatch_exporter_helm_chart_version  = "0.22.0"
 stackdriver_exporter_helm_chart_version = "2.2.0"
 
 allowed_aws_account_ids = ["183375168988"]


### PR DESCRIPTION
This upgrades the `prometheus-cloudwatch-exporter` Helm chart. The most significant changes in the chart were container image version upgrades, from 0.10.0 to 0.15.0.

Most of the changes in cloudwatch-exporter itself were dependency upgrades. It also added an option to cache `ListMetrics` calls, which I enabled since this metadata changes very infrequently in our use case. (The set of values for the QueueName dimension will change when we deploy or tear down a locality) This may save us on the order of $10/month, on top of the operational benefits.