### PR TITLE
Make terraform init follow lockfile

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -40,7 +40,6 @@ prep: ## Prepare a new workspace (environment) if needed, configure the tfstate 
 	@terraform init \
 		-input=false \
 		-force-copy \
-		-upgrade \
 		-backend=true \
 		-backend-config="bucket=$(STATE_BUCKET)"
 
@@ -183,7 +182,6 @@ prep-cluster-bootstrap: ## Prepare a new workspace (environment) if needed, conf
 		init \
 		-input=false \
 		-force-copy \
-		-upgrade \
 		-backend=true \
 		-backend-config="bucket=$(STATE_BUCKET)" \
 		-backend-config="prefix=cluster-bootstrap"


### PR DESCRIPTION
This removes `-upgrade` from our `terraform init` command lines. This will give us more predictable behavior by repeatably installing the same version of our providers. Dependabot handles provider upgrades for us, so we shouldn't have issues with falling way behind.