### PR TITLE
Clippy fixes, 1.67

### DIFF
--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Internet Security Research Group"]
-edition = "2018"
+edition = "2021"
 name = "facilitator"
 version = "0.1.0"
 

--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -89,6 +89,7 @@ pub struct BatchAggregator<'a> {
 }
 
 impl<'a> BatchAggregator<'a> {
+    #[allow(clippy::result_large_err)]
     pub fn new(
         trace_id: &'a Uuid,
         instance_name: &str,
@@ -143,6 +144,7 @@ impl<'a> BatchAggregator<'a> {
     /// Compute the sum part for all the provided batch IDs and write it out to
     /// the aggregation transport. The provided callback is invoked after each
     /// batch is aggregated.
+    #[allow(clippy::result_large_err)]
     pub fn generate_sum_part<F>(
         &mut self,
         batch_ids_and_dates: &[(Uuid, NaiveDateTime)],
@@ -310,6 +312,7 @@ impl<'a> BatchAggregator<'a> {
     /// rejected (in which case other batches in the aggregation window should
     /// still be summed) and `Err` if something went wrong (in which case the
     /// overall aggregation should be aborted).
+    #[allow(clippy::result_large_err)]
     fn aggregate_share(
         &mut self,
         servers: &mut [Server<FieldPriov2>],

--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -313,8 +313,7 @@ impl Provider {
         let oidc_token_variable = Variable::dynamic(move || {
             let token = token_provider.identity_token().map_err(|e| {
                 CredentialsError::new(format!(
-                    "failed to fetch {} identity token from GCP: {}",
-                    purpose, e
+                    "failed to fetch {purpose} identity token from GCP: {e}"
                 ))
             })?;
             Ok(Secret::from(token))
@@ -360,7 +359,7 @@ impl Display for Provider {
                     .as_ref()
                     .map(String::as_str)
                     .unwrap_or_else(|_| "(error resolving variable)");
-                write!(f, "{} via OIDC web identity", role_arn)
+                write!(f, "{role_arn} via OIDC web identity")
             }
             Self::WebIdentityFromKubernetesEnvironment(p) => {
                 let role_arn_res = p.get_ref().get_ref().get_ref().role_arn.resolve();
@@ -368,11 +367,7 @@ impl Display for Provider {
                     .as_ref()
                     .map(String::as_str)
                     .unwrap_or_else(|_| "(error resolving variable)");
-                write!(
-                    f,
-                    "{} via web identity from Kubernetes environment",
-                    role_arn
-                )
+                write!(f, "{role_arn} via web identity from Kubernetes environment")
             }
             #[cfg(test)]
             Self::Mock(_) => write!(f, "mock credentials"),
@@ -850,7 +845,7 @@ pub fn signing_key(
     region: &Region,
     service: &str,
 ) -> Result<Vec<u8>, InvalidLength> {
-    let secret = format!("AWS4{}", secret_key);
+    let secret = format!("AWS4{secret_key}");
     let mut date_hmac: Hmac<Sha256> = Hmac::new_from_slice(secret.as_bytes())?;
     date_hmac.update(datetime.format(SHORT_DATE).to_string().as_bytes());
     let mut region_hmac: Hmac<Sha256> = Hmac::new_from_slice(&date_hmac.finalize().into_bytes())?;

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -719,7 +719,7 @@ mod tests {
         for extension in filenames {
             transport
                 .get(&format!("{base_path}.{extension}"), &DEFAULT_TRACE_ID)
-                .unwrap_or_else(|_| panic!("could not get batch file {}", extension));
+                .unwrap_or_else(|_| panic!("could not get batch file {extension}"));
         }
 
         let mut key_map = HashMap::new();

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -80,8 +80,8 @@ impl Batch<SumPart, InvalidPacket> {
         let filename = format!("sum_{}", i32::from(!is_first));
 
         Self {
-            header_path: format!("{}.{}", batch_path, filename),
-            signature_path: format!("{}.{}.sig", batch_path, filename),
+            header_path: format!("{batch_path}.{filename}"),
+            signature_path: format!("{batch_path}.{filename}.sig"),
             packet_file_path: format!("{}.invalid_uuid_{}.avro", batch_path, i32::from(!is_first)),
 
             phantom_header: PhantomData,
@@ -99,9 +99,9 @@ impl<H: Header, P: Packet> Batch<H, P> {
             batch_id.to_hyphenated()
         );
         Self {
-            header_path: format!("{}.{}", batch_path, filename),
-            signature_path: format!("{}.{}.sig", batch_path, filename),
-            packet_file_path: format!("{}.{}.avro", batch_path, filename),
+            header_path: format!("{batch_path}.{filename}"),
+            signature_path: format!("{batch_path}.{filename}.sig"),
+            packet_file_path: format!("{batch_path}.{filename}.avro"),
             phantom_header: PhantomData,
             phantom_packet: PhantomData,
         }
@@ -718,7 +718,7 @@ mod tests {
         // Verify file layout is as expected
         for extension in filenames {
             transport
-                .get(&format!("{}.{}", base_path, extension), &DEFAULT_TRACE_ID)
+                .get(&format!("{base_path}.{extension}"), &DEFAULT_TRACE_ID)
                 .unwrap_or_else(|_| panic!("could not get batch file {}", extension));
         }
 
@@ -897,12 +897,12 @@ mod tests {
         );
         let idx = i32::from(!is_first);
         let filenames = if single_object_write {
-            vec![format!("validity_{}.sig", idx)]
+            vec![format!("validity_{idx}.sig")]
         } else {
             vec![
-                format!("validity_{}", idx),
-                format!("validity_{}.avro", idx),
-                format!("validity_{}.sig", idx),
+                format!("validity_{idx}"),
+                format!("validity_{idx}.avro"),
+                format!("validity_{idx}.sig"),
             ]
         };
         let read_key = if keys_match {
@@ -1005,12 +1005,12 @@ mod tests {
         );
         let idx = i32::from(!is_first);
         let filenames = if single_object_write {
-            vec![format!("sum_{}.sig", idx)]
+            vec![format!("sum_{idx}.sig")]
         } else {
             vec![
-                format!("sum_{}", idx),
-                format!("invalid_uuid_{}.avro", idx),
-                format!("sum_{}.sig", idx),
+                format!("sum_{idx}"),
+                format!("invalid_uuid_{idx}.avro"),
+                format!("sum_{idx}.sig"),
             ]
         };
         let read_key = if keys_match {

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -72,7 +72,7 @@ fn num_validator<F: FromStr>(s: String) -> Result<(), String> {
 fn date_validator(s: String) -> Result<(), String> {
     NaiveDateTime::parse_from_str(&s, DATE_FORMAT)
         .map(|_| ())
-        .map_err(|e| format!("{} {}", s, e))
+        .map_err(|e| format!("{s} {e}"))
 }
 
 fn uuid_validator(s: String) -> Result<(), String> {
@@ -289,11 +289,10 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                 .env(gcp_sa_to_impersonate_before_assuming_role_env)
                 .value_name("SERVICE_ACCOUNT")
                 .long_help(leak_string(format!(
-                    "If {} is an AWS IAM role and running in GCP, an identity \
+                    "If {id} is an AWS IAM role and running in GCP, an identity \
                     token will be obtained for the specified GCP service \
                     account to then assume the AWS IAM role using STS \
-                    AssumeRoleWithWebIdentity.",
-                    id
+                    AssumeRoleWithWebIdentity."
                 )))
                 .default_value("")
                 .hide_default_value(true),
@@ -1113,7 +1112,7 @@ fn main() -> Result<(), anyhow::Error> {
         // been dropped upon return. slog-scope will panic in this case.
         // Instead, we handle displaying the error and returning an error code
         // manually here, while the guard is still alive.
-        eprintln!("Error: {:?}", error);
+        eprintln!("Error: {error:?}");
         std::process::exit(1);
     }
 
@@ -1232,7 +1231,7 @@ fn get_ecies_public_key(
                 let locality_name = locality_name.ok_or_else(|| {
                     anyhow!("locality-name must be provided with ingestor-manifest-base-url")
                 })?;
-                let peer_name = &format!("{}-{}", locality_name, ingestor_name);
+                let peer_name = &format!("{locality_name}-{ingestor_name}");
                 let manifest = DataShareProcessorSpecificManifest::from_https(
                     manifest_url,
                     peer_name,
@@ -1240,8 +1239,7 @@ fn get_ecies_public_key(
                     api_metrics,
                 )
                 .context(format!(
-                    "unable to read DataShareProcessorSpecificManifest from {}",
-                    manifest_url
+                    "unable to read DataShareProcessorSpecificManifest from {manifest_url}"
                 ))?;
 
                 let (key_identifier, packet_decryption_key) = manifest
@@ -1286,7 +1284,7 @@ fn get_ingestion_identity_and_bucket(
                 .ok_or_else(|| anyhow!("ingestor-name must be provided with manifest-base-url"))?;
             let locality_name = locality_name
                 .ok_or_else(|| anyhow!("locality-name must be provided with manifest-base-url"))?;
-            let peer_name = &format!("{}-{}", locality_name, ingestor_name);
+            let peer_name = &format!("{locality_name}-{ingestor_name}");
             let manifest_url = manifest_url.ok_or_else(|| {
                 anyhow!("If bucket is not provided, manifest_url must be provided")
             })?;
@@ -1298,8 +1296,7 @@ fn get_ingestion_identity_and_bucket(
                 api_metrics,
             )
             .context(format!(
-                "unable to read DataShareProcessorSpecificManifest from {}",
-                manifest_url
+                "unable to read DataShareProcessorSpecificManifest from {manifest_url}"
             ))?;
 
             Ok((
@@ -2235,7 +2232,7 @@ fn lint_manifest(
                     "one of manifest-base-url or manifest-path is required"
                 ));
             };
-            println!("{:#?}", manifest);
+            println!("{manifest:#?}");
         }
         ManifestKind::DataShareProcessorSpecific => {
             let instance = sub_matches
@@ -2267,7 +2264,7 @@ fn lint_manifest(
                     "one of manifest-base-url or manifest-path is required"
                 ));
             };
-            println!("Valid: Ok\n{:#?}", manifest);
+            println!("Valid: Ok\n{manifest:#?}");
         }
     }
 
@@ -2419,7 +2416,7 @@ fn transport_from_args(
             StoragePath::from_str(
                 matches
                     .value_of(path_arg)
-                    .context(format!("{} is required", path_arg))?,
+                    .context(format!("{path_arg} is required"))?,
             )?
         }
     };

--- a/facilitator/src/config.rs
+++ b/facilitator/src/config.rs
@@ -282,7 +282,7 @@ impl FromStr for ManifestKind {
             "data-share-processor-global" => Ok(ManifestKind::DataShareProcessorGlobal),
             "data-share-processor-specific" => Ok(ManifestKind::DataShareProcessorSpecific),
             "portal-global" => Ok(ManifestKind::PortalServerGlobal),
-            _ => Err(anyhow!(format!("unrecognized manifest kind {}", s))),
+            _ => Err(anyhow!(format!("unrecognized manifest kind {s}"))),
         }
     }
 }
@@ -312,7 +312,7 @@ impl FromStr for TaskQueueKind {
         match s {
             "gcp-pubsub" => Ok(TaskQueueKind::GcpPubSub),
             "aws-sqs" => Ok(TaskQueueKind::AwsSqs),
-            _ => Err(anyhow!(format!("unrecognized task queue kind {}", s))),
+            _ => Err(anyhow!(format!("unrecognized task queue kind {s}"))),
         }
     }
 }

--- a/facilitator/src/gcp_oauth.rs
+++ b/facilitator/src/gcp_oauth.rs
@@ -383,7 +383,7 @@ impl ProvideDefaultAccessToken
         let request = self
             .agent
             .prepare_request(RequestParameters {
-                url: parse_url(format!("https://sts.googleapis.com/v1/{}", endpoint))?,
+                url: parse_url(format!("https://sts.googleapis.com/v1/{endpoint}"))?,
                 method: Method::Post,
                 // This request is unauthenticated, except for the signature and
                 // token on the inner subjectToken
@@ -573,8 +573,7 @@ impl GcpAccessTokenProvider {
     /// the provided GCP service account may be obtained
     fn access_token_path_for_service_account(service_account_to_impersonate: &str) -> String {
         format!(
-            "/v1/projects/-/serviceAccounts/{}:generateAccessToken",
-            service_account_to_impersonate
+            "/v1/projects/-/serviceAccounts/{service_account_to_impersonate}:generateAccessToken"
         )
     }
 
@@ -817,10 +816,7 @@ impl ImpersonatedServiceAccountIdentityTokenProvider {
     /// Returns the path relative to an API base URL from which identity tokens for
     /// the provided GCP service account may be obtained
     fn identity_token_path_for_service_account(service_account_to_impersonate: &str) -> String {
-        format!(
-            "/v1/projects/-/serviceAccounts/{}:generateIdToken",
-            service_account_to_impersonate
-        )
+        format!("/v1/projects/-/serviceAccounts/{service_account_to_impersonate}:generateIdToken")
     }
 }
 

--- a/facilitator/src/http.rs
+++ b/facilitator/src/http.rs
@@ -94,7 +94,7 @@ impl RetryingAgent {
             .request_url(parameters.method.to_primitive_string(), &parameters.url);
         if let Some(token_provider) = parameters.token_provider {
             let token = token_provider.ensure_access_token()?;
-            request = request.set("Authorization", &format!("Bearer {}", token));
+            request = request.set("Authorization", &format!("Bearer {token}"));
         }
         Ok(request)
     }

--- a/facilitator/src/http.rs
+++ b/facilitator/src/http.rs
@@ -275,6 +275,7 @@ pub(crate) struct RequestParameters<'a> {
 
 /// simple_get_request does a HTTP request to a URL and returns the body as a
 // string.
+#[allow(clippy::result_large_err)]
 pub(crate) fn simple_get_request(
     url: Url,
     logger: &Logger,

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -349,8 +349,7 @@ impl Header for IngestionHeader {
                         Value::Null => None,
                         v => {
                             return Err(IdlError::MalformedHeader(format!(
-                                "unexpected value {:?} for hamming weight",
-                                v
+                                "unexpected value {v:?} for hamming weight"
                             )));
                         }
                     }
@@ -360,8 +359,7 @@ impl Header for IngestionHeader {
                 ("packet_file_digest", Value::Bytes(v)) => packet_file_digest = Some(v),
                 (f, v) => {
                     return Err(IdlError::MalformedHeader(format!(
-                        "unexpected field {} -> {:?} in record",
-                        f, v
+                        "unexpected field {f} -> {v:?} in record"
                     )))
                 }
             }
@@ -683,8 +681,7 @@ impl Header for ValidationHeader {
                         Value::Null => None,
                         v => {
                             return Err(IdlError::MalformedHeader(format!(
-                                "unexpected value {:?} for hamming weight",
-                                v
+                                "unexpected value {v:?} for hamming weight"
                             )));
                         }
                     }
@@ -692,8 +689,7 @@ impl Header for ValidationHeader {
                 ("packet_file_digest", Value::Bytes(v)) => packet_file_digest = Some(v),
                 (f, v) => {
                     return Err(IdlError::MalformedHeader(format!(
-                        "unexpected field {} -> {:?} in record",
-                        f, v
+                        "unexpected field {f} -> {v:?} in record"
                     )))
                 }
             }
@@ -897,8 +893,7 @@ impl Header for SumPart {
                                     Ok(u)
                                 } else {
                                     Err(IdlError::MalformedHeader(format!(
-                                        "unexpected value in batch_uuids array {:?}",
-                                        value
+                                        "unexpected value in batch_uuids array {value:?}"
                                     )))
                                 }
                             })
@@ -916,8 +911,7 @@ impl Header for SumPart {
                         Value::Null => None,
                         v => {
                             return Err(IdlError::MalformedHeader(format!(
-                                "unexpected value {:?} for hamming weight",
-                                v
+                                "unexpected value {v:?} for hamming weight"
                             )));
                         }
                     }
@@ -931,8 +925,7 @@ impl Header for SumPart {
                                     Ok(l)
                                 } else {
                                     Err(IdlError::MalformedHeader(format!(
-                                        "unexpected value in sum array {:?}",
-                                        value
+                                        "unexpected value in sum array {value:?}"
                                     )))
                                 }
                             })
@@ -949,8 +942,7 @@ impl Header for SumPart {
                 ("total_individual_clients", Value::Long(v)) => total_individual_clients = Some(v),
                 (f, v) => {
                     return Err(IdlError::MalformedHeader(format!(
-                        "unexpected field {} -> {:?} in record",
-                        f, v
+                        "unexpected field {f} -> {v:?} in record"
                     )))
                 }
             }

--- a/facilitator/src/logging.rs
+++ b/facilitator/src/logging.rs
@@ -73,7 +73,7 @@ impl Display for Severity {
             Severity::Warning => "WARNING",
             Severity::Error => "ERROR",
         };
-        write!(f, "{}", string)
+        write!(f, "{string}")
     }
 }
 

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -198,6 +198,7 @@ impl DataShareProcessorSpecificManifest {
     /// Load the specific manifest for the specified peer relative to the
     /// provided base path. Returns an error if the manifest could not be
     /// downloaded or parsed.
+    #[allow(clippy::result_large_err)]
     pub fn from_https(
         base_path: &str,
         peer_name: &str,
@@ -210,6 +211,7 @@ impl DataShareProcessorSpecificManifest {
 
     /// Loads the manifest from the provided String. Returns an error if
     /// the manifest could not be parsed.
+    #[allow(clippy::result_large_err)]
     pub fn from_slice(json: &[u8]) -> Result<Self, Error> {
         // Parse.
         let manifest: DataShareProcessorSpecificManifest =
@@ -400,6 +402,7 @@ impl IngestionServerManifest {
     /// it. First tries to load a global manifest, then falls back to a specific
     /// manifest for the specified locality. Returns an error if no manifest
     /// could be found at either location, or if either was unparseable.
+    #[allow(clippy::result_large_err)]
     pub fn from_https(
         base_path: &str,
         locality: Option<&str>,
@@ -409,6 +412,7 @@ impl IngestionServerManifest {
         IngestionServerManifest::from_http(base_path, locality, logger, fetch_manifest, api_metrics)
     }
 
+    #[allow(clippy::result_large_err)]
     fn from_http(
         base_path: &str,
         locality: Option<&str>,
@@ -435,6 +439,7 @@ impl IngestionServerManifest {
 
     /// Loads the manifest from the provided String. Returns an error if
     /// the manifest could not be parsed.
+    #[allow(clippy::result_large_err)]
     pub fn from_slice(json: &[u8]) -> Result<Self, Error> {
         let manifest: Self =
             serde_json::from_slice(json).context("failed to decode JSON manifest")?;
@@ -523,6 +528,7 @@ type ManifestFetcher = fn(&str, &str, &Logger, &ApiClientMetricsCollector) -> Re
 
 /// Obtains a manifest file from the provided URL, returning an error if the URL
 /// is not https or if a problem occurs during the transfer.
+#[allow(clippy::result_large_err)]
 fn fetch_manifest(
     base_url: &str,
     path: &str,
@@ -537,6 +543,7 @@ fn fetch_manifest(
     fetch_manifest_without_https(base_url, path, logger, service, api_metrics)
 }
 
+#[allow(clippy::result_large_err)]
 fn fetch_manifest_without_https(
     base_url: &str,
     path: &str,
@@ -616,6 +623,7 @@ mod tests {
     use rusoto_core::Region;
     use std::str::FromStr;
 
+    #[allow(clippy::result_large_err)]
     fn http_url_fetcher(
         base_url: &str,
         path: &str,

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -204,7 +204,7 @@ impl DataShareProcessorSpecificManifest {
         logger: &Logger,
         api_metrics: &ApiClientMetricsCollector,
     ) -> Result<Self, Error> {
-        let manifest_path = format!("{}-manifest.json", peer_name);
+        let manifest_path = format!("{peer_name}-manifest.json");
         Self::from_slice(fetch_manifest(base_path, &manifest_path, logger, api_metrics)?.as_bytes())
     }
 
@@ -237,7 +237,7 @@ impl DataShareProcessorSpecificManifest {
                 Ok((
                     k.clone(),
                     public_key_from_pem(&v.public_key)
-                        .with_context(|| format!("couldn't parse key identifier {}", k))?,
+                        .with_context(|| format!("couldn't parse key identifier {k}"))?,
                 ))
             })
             .collect()
@@ -318,13 +318,11 @@ impl DataShareProcessorSpecificManifest {
         let test_message: Vec<u8> = (0..100).map(|_| rand::random::<u8>()).collect();
         'outer: for (identifier, csr) in self.packet_encryption_keys() {
             let public_key = PublicKey::from_base64(&csr.base64_public_key()?).context(format!(
-                "failed to decode packet encryption public key {} from specific manifest",
-                identifier,
+                "failed to decode packet encryption public key {identifier} from specific manifest",
             ))?;
 
             let encrypted = encrypt_share(&test_message, &public_key).context(format!(
-                "failed to encrypt test message to packet encryption public key {}",
-                identifier,
+                "failed to encrypt test message to packet encryption public key {identifier}",
             ))?;
 
             for private_key in packet_encryption_private_keys {
@@ -424,7 +422,7 @@ impl IngestionServerManifest {
                 Some(locality) => IngestionServerManifest::from_slice(
                     fetcher(
                         base_path,
-                        &format!("{}-manifest.json", locality),
+                        &format!("{locality}-manifest.json"),
                         logger,
                         api_metrics,
                     )?
@@ -456,7 +454,7 @@ impl IngestionServerManifest {
             keys.insert(
                 identifier.clone(),
                 public_key_from_pem(&public_key.public_key)
-                    .with_context(|| format!("couldn't parse key identifier {}", identifier))?,
+                    .with_context(|| format!("couldn't parse key identifier {identifier}"))?,
             );
         }
         Ok(keys)
@@ -546,7 +544,7 @@ fn fetch_manifest_without_https(
     service: &str,
     api_metrics: &ApiClientMetricsCollector,
 ) -> Result<String, Error> {
-    let manifest_url = format!("{}/{}", base_url, path);
+    let manifest_url = format!("{base_url}/{path}");
 
     http::simple_get_request(parse_url(manifest_url)?, logger, service, api_metrics)
 }
@@ -565,7 +563,7 @@ fn public_key_from_pem(pem_key: &str) -> Result<UnparsedPublicKey<Vec<u8>>> {
     if pem_key.is_empty() {
         return Err(anyhow!("empty PEM input"));
     }
-    let pem = pem::parse(pem_key).context(format!("failed to parse key as PEM: {}", pem_key))?;
+    let pem = pem::parse(pem_key).context(format!("failed to parse key as PEM: {pem_key}"))?;
     const WANT_PEM_TAG: &str = "PUBLIC KEY";
     if pem.tag != WANT_PEM_TAG {
         return Err(anyhow!(
@@ -865,21 +863,20 @@ mod tests {
     "format": 1,
     "packet-encryption-keys": {{
         "fake-key-1": {{
-            "certificate-signing-request": "-----BEGIN CERTIFICATE REQUEST-----\n{}\n-----END CERTIFICATE REQUEST-----\n"
+            "certificate-signing-request": "-----BEGIN CERTIFICATE REQUEST-----\n{DEFAULT_PACKET_ENCRYPTION_CSR}\n-----END CERTIFICATE REQUEST-----\n"
         }}
     }},
     "batch-signing-public-keys": {{
         "fake-key-2": {{
         "expiration": "",
-        "public-key": "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----\n"
+        "public-key": "-----BEGIN PUBLIC KEY-----\n{DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO}\n-----END PUBLIC KEY-----\n"
       }}
     }},
     "ingestion-bucket": "s3://us-west-1/ingestion",
     "ingestion-identity": "arn:aws:iam:something:fake",
     "peer-validation-bucket": "gs://validation/path/fragment"
 }}
-    "#,
-            DEFAULT_PACKET_ENCRYPTION_CSR, DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO
+    "#
         );
         let manifest = DataShareProcessorSpecificManifest::from_slice(json.as_bytes()).unwrap();
 
@@ -889,8 +886,7 @@ mod tests {
             BatchSigningPublicKey {
                 expiration: "".to_string(),
                 public_key: format!(
-                    "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----\n",
-                    DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO
+                    "-----BEGIN PUBLIC KEY-----\n{DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO}\n-----END PUBLIC KEY-----\n"
                 ),
             },
         );
@@ -899,8 +895,7 @@ mod tests {
             "fake-key-1".to_owned(),
             PacketEncryptionCertificateSigningRequest {
                 certificate_signing_request: format!(
-                    "-----BEGIN CERTIFICATE REQUEST-----\n{}\n-----END CERTIFICATE REQUEST-----\n",
-                    DEFAULT_PACKET_ENCRYPTION_CSR
+                    "-----BEGIN CERTIFICATE REQUEST-----\n{DEFAULT_PACKET_ENCRYPTION_CSR}\n-----END CERTIFICATE REQUEST-----\n"
                 ),
             },
         );

--- a/facilitator/src/metrics.rs
+++ b/facilitator/src/metrics.rs
@@ -191,10 +191,9 @@ pub struct BatchReaderMetricsCollector {
 impl BatchReaderMetricsCollector {
     pub fn new(ownership: &str) -> Result<Self> {
         let invalid_validation_batches = register_int_counter_vec!(
-            format!("facilitator_invalid_{}_validation_batches", ownership),
+            format!("facilitator_invalid_{ownership}_validation_batches"),
             format!(
-                "Number of invalid {} validation batches encountered during aggregation",
-                ownership
+                "Number of invalid {ownership} validation batches encountered during aggregation"
             ),
             &["reason"]
         )
@@ -218,7 +217,7 @@ impl ApiClientMetricsCollector {
 
     pub(crate) fn new_with_metric_name(name: &'static str) -> Result<Self> {
         let latency = register_histogram_vec!(
-            format!("facilitator_api_latency_ms{}", name),
+            format!("facilitator_api_latency_ms{name}"),
             "Latencies in milliseconds on successful API requests",
             &["service", "endpoint", "status"],
             // Buckets cribbed from Boulder's metrics.InternetFacingBuckets

--- a/facilitator/src/retries.rs
+++ b/facilitator/src/retries.rs
@@ -62,7 +62,7 @@ where
             if is_retryable(&error) {
                 warn!(
                     logger, "encountered retryable error";
-                    "error" => format!("{:?}", error),
+                    "error" => format!("{error:?}"),
                 );
                 backoff::Error::transient(error)
             } else {
@@ -139,7 +139,7 @@ where
                 if is_retryable(&error) {
                     warn!(
                         logger, "encountered retryable error";
-                        "error" => format!("{:?}", error),
+                        "error" => format!("{error:?}"),
                     );
                     backoff::Error::transient(error)
                 } else {

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -472,7 +472,7 @@ mod tests {
                 10,
             )
             .unwrap();
-        let expected_path = format!("fake-aggregation/2009/02/13/23/31/{}.batch", batch_uuid);
+        let expected_path = format!("fake-aggregation/2009/02/13/23/31/{batch_uuid}.batch");
 
         let transports = &mut [
             LocalFileTransport::new(tempdir.path().to_path_buf().join("pha")),

--- a/facilitator/src/task.rs
+++ b/facilitator/src/task.rs
@@ -173,7 +173,7 @@ pub struct TaskHandle<T: Task> {
 // with minimal ceremony.
 impl<T: Task> Value for TaskHandle<T> {
     fn serialize(&self, _: &Record<'_>, key: Key, serializer: &mut dyn Serializer) -> slog::Result {
-        serializer.emit_str(key, &format!("{}", self))
+        serializer.emit_str(key, &format!("{self}"))
     }
 }
 

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -26,8 +26,7 @@ fn gcp_pubsub_pull_url(
     subscription_id: &str,
 ) -> Result<Url, UrlParseError> {
     let request_url = format!(
-        "{}/v1/projects/{}/subscriptions/{}:pull",
-        pubsub_api_endpoint, gcp_project_id, subscription_id
+        "{pubsub_api_endpoint}/v1/projects/{gcp_project_id}/subscriptions/{subscription_id}:pull"
     );
     parse_url(request_url)
 }
@@ -39,8 +38,7 @@ fn gcp_pubsub_ack_url(
     subscription_id: &str,
 ) -> Result<Url, UrlParseError> {
     let request_url = format!(
-        "{}/v1/projects/{}/subscriptions/{}:acknowledge",
-        pubsub_api_endpoint, gcp_project_id, subscription_id
+        "{pubsub_api_endpoint}/v1/projects/{gcp_project_id}/subscriptions/{subscription_id}:acknowledge"
     );
     parse_url(request_url)
 }
@@ -52,8 +50,7 @@ fn gcp_pubsub_modify_ack_deadline(
     subscription_id: &str,
 ) -> Result<Url, UrlParseError> {
     let request_url = format!(
-        "{}/v1/projects/{}/subscriptions/{}:modifyAckDeadline",
-        pubsub_api_endpoint, gcp_project_id, subscription_id
+        "{pubsub_api_endpoint}/v1/projects/{gcp_project_id}/subscriptions/{subscription_id}:modifyAckDeadline"
     );
     parse_url(request_url)
 }
@@ -64,10 +61,8 @@ fn gcp_pubsub_publish_url(
     gcp_project_id: &str,
     topic: &str,
 ) -> Result<Url, UrlParseError> {
-    let request_url = format!(
-        "{}/v1/projects/{}/topics/{}:publish",
-        pubsub_api_endpoint, gcp_project_id, topic
-    );
+    let request_url =
+        format!("{pubsub_api_endpoint}/v1/projects/{gcp_project_id}/topics/{topic}:publish");
     parse_url(request_url)
 }
 
@@ -226,7 +221,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
         let task_json =
             String::from_utf8(task_bytes).context("failed to decode PubSub message from UTF-8")?;
         let task: T = serde_json::from_reader(task_json.as_bytes())
-            .context(format!("failed to decode task {:?} from JSON", task_json))?;
+            .context(format!("failed to decode task {task_json:?} from JSON"))?;
 
         let published_time =
             DateTime::parse_from_rfc3339(&received_message.message.publish_time)?.naive_utc();
@@ -266,7 +261,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
                     "ackIds": [handle.acknowledgment_id]
                 }),
             )
-            .context(format!("failed to acknowledge task {:?}", handle,))?;
+            .context(format!("failed to acknowledge task {handle:?}",))?;
 
         Ok(())
     }
@@ -322,7 +317,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
                     "messages": [{"data": BASE64_STANDARD.encode(&handle.raw_body)}]
                 }),
             )
-            .context(format!("failed to forward task {:?}", handle))?;
+            .context(format!("failed to forward task {handle:?}"))?;
 
         self.acknowledge_task(handle)
     }
@@ -363,10 +358,7 @@ impl<T: Task> GcpPubSubTaskQueue<T> {
                     "ackDeadlineSeconds": ack_deadline.as_secs(),
                 }),
             )
-            .context(format!(
-                "failed to modify ack deadline on task {:?}",
-                handle,
-            ))?;
+            .context(format!("failed to modify ack deadline on task {handle:?}",))?;
 
         Ok(())
     }

--- a/facilitator/src/task/sqs.rs
+++ b/facilitator/src/task/sqs.rs
@@ -128,7 +128,7 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
         };
 
         let task = serde_json::from_reader(body.as_bytes())
-            .context(format!("failed to decode JSON task {:?}", body))?;
+            .context(format!("failed to decode JSON task {body:?}"))?;
 
         Ok(Some(TaskHandle {
             task,
@@ -272,8 +272,7 @@ impl<T: Task> AwsSqsTaskQueue<T> {
         let client = self.sqs_client()?;
 
         let timeout = i64::try_from(visibility_timeout.as_secs()).context(format!(
-            "timeout value {:?} cannot be encoded into ChangeMessageVisibilityRequest",
-            visibility_timeout
+            "timeout value {visibility_timeout:?} cannot be encoded into ChangeMessageVisibilityRequest"
         ))?;
 
         retry_request(

--- a/facilitator/src/transport.rs
+++ b/facilitator/src/transport.rs
@@ -70,6 +70,7 @@ pub trait TransportWriter: Write {
     ///
     /// The `TransportWriter` cannot be used after this method is called,
     /// regardlesss of whether it succeeds.
+    #[allow(clippy::result_large_err)]
     fn complete_upload(&mut self) -> Result<(), TransportError>;
 
     /// Cancel an upload operation, cleaning up any related resources. This
@@ -80,6 +81,7 @@ pub trait TransportWriter: Write {
     ///
     /// The `TransportWriter` cannot be used after this method is called,
     /// regardlesss of whether it succeeds.
+    #[allow(clippy::result_large_err)]
     fn cancel_upload(&mut self) -> Result<(), TransportError>;
 }
 
@@ -104,10 +106,12 @@ pub trait Transport: Debug + DynClone + Send {
     /// Returns an std::io::Read instance from which the contents of the value
     /// of the provided key may be read. If no object is found, an error
     /// wrapping ObjectNotFoundError is returned.
+    #[allow(clippy::result_large_err)]
     fn get(&self, key: &str, trace_id: &Uuid) -> Result<Box<dyn Read>, TransportError>;
 
     /// Returns an std::io::Write instance into which the contents of the value
     /// may be written.
+    #[allow(clippy::result_large_err)]
     fn put(&self, key: &str, trace_id: &Uuid) -> Result<Box<dyn TransportWriter>, TransportError>;
 
     fn path(&self) -> String;

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -38,7 +38,7 @@ fn gcp_object_url(bucket: &str, encoded_key: &str) -> Result<Url, UrlParseError>
 }
 
 fn gcp_upload_object_url(storage_api_url: &str, bucket: &str) -> Result<Url, UrlParseError> {
-    let request_url = format!("{}upload/storage/v1/b/{}/o/", storage_api_url, bucket);
+    let request_url = format!("{storage_api_url}upload/storage/v1/b/{bucket}/o/");
 
     parse_url(request_url)
 }

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -297,6 +297,7 @@ impl MultipartUploadWriter {
     }
 
     /// Upload content in internal buffer, if any, to S3 in an UploadPart call.
+    #[allow(clippy::result_large_err)]
     fn upload_part(&mut self) -> Result<(), TransportError> {
         if self.buffer.is_empty() {
             return Ok(());

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -647,8 +647,7 @@ mod tests {
         .expect_err("expected error");
         assert!(
             matches!(err, S3Error::CreateMultipartUpload(_, _)),
-            "found unexpected error {:?}",
-            err
+            "found unexpected error {err:?}"
         );
 
         mocked_upload.assert();

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -519,15 +519,14 @@ mod tests {
 
     fn mock_create_multipart_upload_request(bucket: &str, key: &str, upload_id: &str) -> Mock {
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
-        let path = format!("/{}/{}", bucket, key);
+        let path = format!("/{bucket}/{key}");
         let response_body = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <InitiateMultipartUploadResult>
-   <Bucket>{}</Bucket>
-   <Key>{}</Key>
-   <UploadId>{}</UploadId>
-</InitiateMultipartUploadResult>"#,
-            bucket, key, upload_id
+   <Bucket>{bucket}</Bucket>
+   <Key>{key}</Key>
+   <UploadId>{upload_id}</UploadId>
+</InitiateMultipartUploadResult>"#
         );
         mock("POST", Matcher::Exact(path))
             .match_query(has_query_parameter("uploads"))
@@ -543,7 +542,7 @@ mod tests {
         part_number: u64,
     ) -> Mock {
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
-        let path = format!("/{}/{}", bucket, key);
+        let path = format!("/{bucket}/{key}");
         mock("PUT", Matcher::Exact(path)).match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("partNumber".to_string(), part_number.to_string()),
             Matcher::UrlEncoded("uploadId".to_string(), upload_id.to_string()),
@@ -564,7 +563,7 @@ mod tests {
 
     fn mock_abort_multipart_upload_request(bucket: &str, key: &str, upload_id: &str) -> Mock {
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
-        let path = format!("/{}/{}", bucket, key);
+        let path = format!("/{bucket}/{key}");
         mock("DELETE", Matcher::Exact(path))
             .match_query(Matcher::UrlEncoded(
                 "uploadId".to_string(),
@@ -580,16 +579,15 @@ mod tests {
         part_etags: Vec<&str>,
     ) -> Mock {
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
-        let path = format!("/{}/{}", bucket, key);
+        let path = format!("/{bucket}/{key}");
         let response_body = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <CompleteMultipartUploadResult>
    <Location>fake-final-location</Location>
-   <Bucket>{}</Bucket>
-   <Key>{}</Key>
+   <Bucket>{bucket}</Bucket>
+   <Key>{key}</Key>
    <ETag>fake-final-etag</ETag>
-</CompleteMultipartUploadResult>"#,
-            bucket, key
+</CompleteMultipartUploadResult>"#
         );
         let body_matchers: Vec<Matcher> = part_etags
             .into_iter()
@@ -605,7 +603,7 @@ mod tests {
     }
 
     fn mock_get_object_request(bucket: &str, key: &str) -> Mock {
-        let path = format!("/{}/{}", bucket, key);
+        let path = format!("/{bucket}/{key}");
         mock("GET", Matcher::Exact(path)).match_query(Matcher::Missing)
     }
 

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -749,9 +749,8 @@ fn end_to_end_test(test_options: EndToEndTestOptions) {
     };
     assert_eq!(
         reconstructed, reference_sum,
-        "reconstructed shares do not match original data.\npha sum: {:?}\n
-            facilitator sum: {:?}\nreconstructed sum: {:?}\nreference sum: {:?}",
-        pha_sum_fields, facilitator_sum_fields, reconstructed, reference_sum
+        "reconstructed shares do not match original data.\npha sum: {pha_sum_fields:?}\n
+            facilitator sum: {facilitator_sum_fields:?}\nreconstructed sum: {reconstructed:?}\nreference sum: {reference_sum:?}"
     );
 
     assert_eq!(expected_batch_uuids, facilitator_sum_part.batch_uuids);


### PR DESCRIPTION
This bumps the crate's edition to 2021 to make `panic!()`/`assert!()` improvements available, rewrites format strings to fix lints, and ignores more `clippy::result_large_err` lints.