### PR TITLE
Upgrade libprio-rs to 0.10.0

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -30,10 +30,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
- "ctr",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.3",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -43,9 +53,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
- "aes",
- "cipher",
- "ctr",
+ "aes 0.7.5",
+ "cipher 0.3.0",
+ "ctr 0.8.0",
  "ghash",
  "subtle",
 ]
@@ -88,18 +98,6 @@ name = "arc-swap"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
-
-[[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 
 [[package]]
 name = "assert-json-diff"
@@ -170,6 +168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
 name = "b64-ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,7 +186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom 0.2.3",
+ "getrandom 0.2.8",
  "instant",
  "pin-project-lite",
  "rand 0.8.5",
@@ -235,20 +239,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake3"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "digest 0.10.6",
 ]
 
 [[package]]
@@ -319,10 +309,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
-name = "byteorder"
-version = "1.4.2"
+name = "bytemuck"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -368,6 +364,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +386,17 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "cmac"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "606383658416244b8dc4b36f864ec1f86cb922b95c41a908fd07aeb01cad06fa"
+dependencies = [
+ "cipher 0.4.3",
+ "dbl",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -415,12 +432,6 @@ name = "const-oid"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "content_inspector"
@@ -520,6 +531,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,7 +574,25 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.3",
+]
+
+[[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -810,6 +845,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed"
+version = "1.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e55932f129b8e8582d2099dd43f67c9e641a9369280fac04ac97c47ba1564e"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "typenum",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,13 +1010,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1016,6 +1063,15 @@ dependencies = [
  "tokio",
  "tokio-util 0.6.9",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1221,6 +1277,15 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -1750,16 +1815,18 @@ dependencies = [
 
 [[package]]
 name = "prio"
-version = "0.6.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13e53b3cc5257af57c65d674ef0cd4d4de8bde6739833424a4bb52493b4d897"
+checksum = "a0453e1ec5f2f48af9a67aab1d812f9aec48619dda0d9a59e2f79ebd235448ec"
 dependencies = [
- "aes",
+ "aes 0.8.2",
  "aes-gcm",
  "base64 0.13.1",
- "blake3",
- "cipher",
- "getrandom 0.2.3",
+ "byteorder",
+ "cmac",
+ "ctr 0.9.2",
+ "fixed",
+ "getrandom 0.2.8",
  "ring",
  "serde",
  "static_assertions",
@@ -1900,7 +1967,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -1952,7 +2019,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.8",
  "redox_syscall",
 ]
 
@@ -3151,9 +3218,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
@@ -3212,7 +3279,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.8",
  "serde",
 ]
 

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1"
 p256 = "0.12.0"
 pem = "1.1"
 pkix = "0.2.1"
-prio = "0.6.1"
+prio = { version = "0.10.0", features = ["prio2"] }
 prometheus = { version = "0.13", features = ["process"] }
 rand = "0.8"
 ring = { version = "0.16.20", features = ["std"] }

--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use chrono::NaiveDateTime;
 use prio::{
-    field::FieldPriov2,
+    field::FieldPrio2,
     server::{Server, VerificationMessage},
 };
 use slog::{info, o, warn, Logger};
@@ -315,7 +315,7 @@ impl<'a> BatchAggregator<'a> {
     #[allow(clippy::result_large_err)]
     fn aggregate_share(
         &mut self,
-        servers: &mut [Server<FieldPriov2>],
+        servers: &mut [Server<FieldPrio2>],
         invalid_uuids: &mut Vec<Uuid>,
         ingestion_packets: Vec<IngestionDataSharePacket>,
         peer_validation_packets: Vec<ValidationPacket>,

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -6,7 +6,7 @@ use chrono::{prelude::Utc, NaiveDateTime};
 use clap::{value_t, App, Arg, ArgGroup, ArgMatches, SubCommand};
 use prio::{
     encrypt::{PrivateKey, PublicKey},
-    field::FieldPriov2,
+    field::FieldPrio2,
     util::reconstruct_shares,
 };
 use prometheus::{register_int_counter_vec, IntCounterVec};
@@ -1611,15 +1611,15 @@ fn validate_sample(
     .read(facilitator_pubkey_map)
     .map_err(|e| Error::AnyhowError(e.into()))?;
 
-    let pha_accumulated_share: Vec<FieldPriov2> = pha_sum_part
+    let pha_accumulated_share: Vec<FieldPrio2> = pha_sum_part
         .sum
         .into_iter()
-        .map(|v| FieldPriov2::from(u32::try_from(v).unwrap()))
+        .map(|v| FieldPrio2::from(u32::try_from(v).unwrap()))
         .collect();
-    let facilitator_accumulated_share: Vec<FieldPriov2> = facilitator_sum_part
+    let facilitator_accumulated_share: Vec<FieldPrio2> = facilitator_sum_part
         .sum
         .into_iter()
-        .map(|v| FieldPriov2::from(u32::try_from(v).unwrap()))
+        .map(|v| FieldPrio2::from(u32::try_from(v).unwrap()))
         .collect();
     let actual_sum =
         reconstruct_shares(&pha_accumulated_share, &facilitator_accumulated_share).unwrap();

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -6,7 +6,7 @@ use avro_rs::{
 };
 use lazy_static::lazy_static;
 use prio::{
-    field::FieldPriov2,
+    field::FieldPrio2,
     server::{Server, ServerError, VerificationMessage},
 };
 use serde::{Deserialize, Serialize};
@@ -566,9 +566,9 @@ impl TryFrom<Value> for IngestionDataSharePacket {
 impl IngestionDataSharePacket {
     pub(crate) fn generate_validation_packet(
         &self,
-        servers: &mut [Server<FieldPriov2>],
+        servers: &mut [Server<FieldPrio2>],
     ) -> Result<ValidationPacket, IntakeError> {
-        let r_pit = FieldPriov2::from(
+        let r_pit = FieldPrio2::from(
             u32::try_from(self.r_pit)
                 .map_err(|_| IntakeError::Idl(IdlError::OverflowingRPit(self.r_pit)))?,
         );
@@ -805,14 +805,14 @@ impl TryFrom<Value> for ValidationPacket {
     }
 }
 
-impl TryFrom<&ValidationPacket> for VerificationMessage<FieldPriov2> {
+impl TryFrom<&ValidationPacket> for VerificationMessage<FieldPrio2> {
     type Error = TryFromIntError;
 
     fn try_from(p: &ValidationPacket) -> Result<Self, Self::Error> {
         Ok(VerificationMessage {
-            f_r: FieldPriov2::from(u32::try_from(p.f_r)?),
-            g_r: FieldPriov2::from(u32::try_from(p.g_r)?),
-            h_r: FieldPriov2::from(u32::try_from(p.h_r)?),
+            f_r: FieldPrio2::from(u32::try_from(p.f_r)?),
+            g_r: FieldPrio2::from(u32::try_from(p.g_r)?),
+            h_r: FieldPrio2::from(u32::try_from(p.h_r)?),
         })
     }
 }
@@ -834,10 +834,10 @@ pub struct SumPart {
 }
 
 impl SumPart {
-    pub fn sum(&self) -> Result<Vec<FieldPriov2>, TryFromIntError> {
+    pub fn sum(&self) -> Result<Vec<FieldPrio2>, TryFromIntError> {
         self.sum
             .iter()
-            .map(|i| Ok(FieldPriov2::from(u32::try_from(*i)?)))
+            .map(|i| Ok(FieldPrio2::from(u32::try_from(*i)?)))
             .collect()
     }
 }

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -11,7 +11,7 @@ use crate::{
 use chrono::NaiveDateTime;
 use prio::{
     encrypt::{PrivateKey, PublicKey},
-    field::FieldPriov2,
+    field::FieldPrio2,
     server::Server,
 };
 use ring::signature::UnparsedPublicKey;
@@ -180,7 +180,7 @@ impl<'a> BatchIntaker<'a> {
         // is optional. Instead we try all the keys we have available until one
         // works.
         // https://github.com/abetterinternet/prio-server/issues/73
-        let mut servers: Vec<Server<FieldPriov2>> = self
+        let mut servers: Vec<Server<FieldPrio2>> = self
             .packet_decryption_keys
             .iter()
             .map(|k| {

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -11,7 +11,7 @@ use chrono::NaiveDateTime;
 use prio::{
     client::Client,
     encrypt::PublicKey,
-    field::{FieldElement, FieldPriov2},
+    field::{FieldElement, FieldPrio2},
 };
 use ring::digest;
 use slog::{info, o, Logger};
@@ -47,7 +47,7 @@ impl SampleOutput {
 pub struct ReferenceSum {
     /// The reference sum, covering those packets whose shares appear in both
     /// PHA and facilitator ingestion batches.
-    pub sum: Vec<FieldPriov2>,
+    pub sum: Vec<FieldPrio2>,
     /// The number of contributions that went into the reference sum.
     pub contributions: usize,
     /// UUIDs of PHA packets that were dropped
@@ -209,7 +209,7 @@ impl<'a> SampleGenerator<'a> {
         let batch_start_time = self.batch_start_time;
         let batch_end_time = self.batch_end_time;
 
-        let mut reference_sum = vec![FieldPriov2::from(0); self.dimension as usize];
+        let mut reference_sum = vec![FieldPrio2::from(0); self.dimension as usize];
         let mut contributions = 0;
         let mut pha_packets = Vec::new();
         let mut pha_dropped_packets = Vec::new();
@@ -298,7 +298,7 @@ impl<'a> SampleGenerator<'a> {
                 name: aggregation_name.to_owned(),
                 bins: dimension,
                 epsilon,
-                prime: FieldPriov2::modulus() as i64,
+                prime: FieldPrio2::modulus() as i64,
                 number_of_servers: 2,
                 hamming_weight: None,
                 batch_start_time,
@@ -314,7 +314,7 @@ impl<'a> SampleGenerator<'a> {
                 name: aggregation_name.to_owned(),
                 bins: dimension,
                 epsilon,
-                prime: FieldPriov2::modulus() as i64,
+                prime: FieldPrio2::modulus() as i64,
                 number_of_servers: 2,
                 hamming_weight: None,
                 batch_start_time,
@@ -345,9 +345,9 @@ pub fn expected_sample_sum_for_batches(
     batch_uuids: &[Uuid],
     dimension: i32,
     packet_count: usize,
-) -> Vec<FieldPriov2> {
+) -> Vec<FieldPrio2> {
     let dimension = dimension as usize;
-    let mut sum = vec![FieldPriov2::from(0); dimension];
+    let mut sum = vec![FieldPrio2::from(0); dimension];
 
     for batch_uuid in batch_uuids {
         for packet_data in sample_data_iterator(batch_uuid, dimension).take(packet_count) {
@@ -369,7 +369,7 @@ pub fn expected_sample_sum_for_batches(
 fn sample_data_iterator(
     batch_uuid: &Uuid,
     dimension: usize,
-) -> impl Iterator<Item = Vec<FieldPriov2>> {
+) -> impl Iterator<Item = Vec<FieldPrio2>> {
     // Ensure preconditions.
     static DIGEST_ALGORITHM: &digest::Algorithm = &digest::SHA512_256;
     assert!(
@@ -393,7 +393,7 @@ fn sample_data_iterator(
             .as_bits::<Msb0>()
             .iter()
             .take(dimension)
-            .map(|bit| FieldPriov2::from(*bit as u32))
+            .map(|bit| FieldPrio2::from(*bit as u32))
             .collect()
     })
 }
@@ -486,7 +486,7 @@ mod tests {
             assert_eq!(parsed_header.name, "fake-aggregation".to_owned());
             assert_eq!(parsed_header.bins, 10);
             assert_eq!(parsed_header.epsilon, 0.11);
-            assert_eq!(parsed_header.prime, FieldPriov2::modulus() as i64);
+            assert_eq!(parsed_header.prime, FieldPrio2::modulus() as i64);
             assert_eq!(parsed_header.number_of_servers, 2);
             assert_eq!(parsed_header.hamming_weight, None);
             assert_eq!(parsed_header.batch_start_time, 100);
@@ -543,7 +543,7 @@ mod tests {
         );
 
         // Determine actual sum, per calls to generate_ingestion_sample.
-        let mut actual_sum = vec![FieldPriov2::from(0); DIMENSION as usize];
+        let mut actual_sum = vec![FieldPrio2::from(0); DIMENSION as usize];
         for batch_uuid in batch_uuids {
             let batch_sum = sample_generator
                 .generate_ingestion_sample(


### PR DESCRIPTION
This updates libprio-rs from 0.6.1 to 0.10.0, to get us off an unsupported version. I plan to test this in a development environment to make sure everything still works.