### PR TITLE
Reduce alert sensitivity for intake error rate

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -15,8 +15,8 @@ groups:
         instance {{ $labels.locality }}-{{ $labels.ingestor }} in environment
         ${environment} last ran successfully"
   - alert: facilitator_intake_failure_rate
-    expr: (sum without (status) (rate(facilitator_intake_tasks_finished{status="success"}[1h])))
-      / (sum without (status) (rate(facilitator_intake_tasks_finished[1h]))) < 0.95
+    expr: (sum without (status, aggregation_id) (rate(facilitator_intake_tasks_finished{status="success"}[1h])))
+      / (sum without (status, aggregation_id) (rate(facilitator_intake_tasks_finished[1h]))) < 0.90
     for: 5m
     labels:
       severity: page
@@ -26,11 +26,11 @@ groups:
         {{ $labels.namespace }}-{{ $labels.service }}"
       description: "intake worker instance {{ $labels.namespace }}-
         {{ $labels.service }} in environment ${environment} is failing
-        more than 5% of the time in the last hour"
+        more than 10% of the time in the last hour"
   - alert: facilitator_aggregate_failure_rate
     # aggregations run much less often than intake so use a larger window of time
-    expr: (sum without (status) (rate(facilitator_aggregate_tasks_finished{status="success"}[${aggregation_period}])))
-      / (sum without (status) (rate(facilitator_aggregate_tasks_finished[${aggregation_period}]))) < 0.95
+    expr: (sum without (status, aggregation_id) (rate(facilitator_aggregate_tasks_finished{status="success"}[${aggregation_period}])))
+      / (sum without (status, aggregation_id) (rate(facilitator_aggregate_tasks_finished[${aggregation_period}]))) < 0.95
     for: 5m
     labels:
       severity: page
@@ -42,8 +42,8 @@ groups:
         {{ $labels.service }} in environment ${environment} is failing
         more than 5% of the time in the last 8 hours"
   - alert: facilitator_intake_rejection_rate
-    expr: (sum without (status) (rate(facilitator_intake_tasks_finished{status="rejected"}[1h])))
-      / (sum without (status) (rate(facilitator_intake_tasks_finished[1h]))) > 0.01
+    expr: (sum without (status, aggregation_id) (rate(facilitator_intake_tasks_finished{status="rejected"}[1h])))
+      / (sum without (status, aggregation_id) (rate(facilitator_intake_tasks_finished[1h]))) > 0.10
     for: 5m
     labels:
       severity: page
@@ -53,10 +53,10 @@ groups:
         {{ $labels.namespace }}-{{ $labels.service }}"
       description: "intake worker instance {{ $labels.namespace }}-
         {{ $labels.service }} in environment ${environment} has
-        rejected more than 1% of tasks in the last hour"
+        rejected more than 10% of tasks in the last hour"
   - alert: facilitator_aggregate_rejection_rate
-    expr: (sum without (status) (rate(facilitator_aggregate_tasks_finished{status="rejected"}[${aggregation_period}])))
-      / (sum without (status) (rate(facilitator_aggregate_tasks_finished[${aggregation_period}]))) > 0.01
+    expr: (sum without (status, aggregation_id) (rate(facilitator_aggregate_tasks_finished{status="rejected"}[${aggregation_period}])))
+      / (sum without (status, aggregation_id) (rate(facilitator_aggregate_tasks_finished[${aggregation_period}]))) > 0.01
     for: 5m
     labels:
       severity: page


### PR DESCRIPTION
This makes two changes to alerts which have been firing continuously since we deleted year-old keys. First, the failure rate/rejection rate alerts are all changed to sum over the aggregation ID as well. This is needed because devices having old configurations causes both uploads with expired keys and uploads to old aggregation IDs that are no longer requested. Thus, there are some aggregation IDs with 100% failure rate. Averaging over these removes the outliers, while still capturing per-locality and per-ingestor error rates.

Secondly, the thresholds for both the intake failure rate and intake rejection rate are changed to 10%. After the aggregation change, most localities have error rates in the low percents, but there are a couple with error rates at 7% or 8%. These thresholds thus have to go up past the background error rate, at least for now.