### PR TITLE
Further summarize metrics for error rate alerts

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -15,8 +15,8 @@ groups:
         instance {{ $labels.locality }}-{{ $labels.ingestor }} in environment
         ${environment} last ran successfully"
   - alert: facilitator_intake_failure_rate
-    expr: (sum without (status, aggregation_id) (rate(facilitator_intake_tasks_finished{status="success"}[1h])))
-      / (sum without (status, aggregation_id) (rate(facilitator_intake_tasks_finished[1h]))) < 0.90
+    expr: (sum without (status, aggregation_id, instance, node) (rate(facilitator_intake_tasks_finished{status="success"}[1h])))
+      / (sum without (status, aggregation_id, instance, node) (rate(facilitator_intake_tasks_finished[1h]))) < 0.90
     for: 5m
     labels:
       severity: page
@@ -29,8 +29,8 @@ groups:
         more than 10% of the time in the last hour"
   - alert: facilitator_aggregate_failure_rate
     # aggregations run much less often than intake so use a larger window of time
-    expr: (sum without (status, aggregation_id) (rate(facilitator_aggregate_tasks_finished{status="success"}[${aggregation_period}])))
-      / (sum without (status, aggregation_id) (rate(facilitator_aggregate_tasks_finished[${aggregation_period}]))) < 0.95
+    expr: (sum without (status, aggregation_id, instance, node) (rate(facilitator_aggregate_tasks_finished{status="success"}[${aggregation_period}])))
+      / (sum without (status, aggregation_id, instance, node) (rate(facilitator_aggregate_tasks_finished[${aggregation_period}]))) < 0.95
     for: 5m
     labels:
       severity: page
@@ -42,8 +42,8 @@ groups:
         {{ $labels.service }} in environment ${environment} is failing
         more than 5% of the time in the last 8 hours"
   - alert: facilitator_intake_rejection_rate
-    expr: (sum without (status, aggregation_id) (rate(facilitator_intake_tasks_finished{status="rejected"}[1h])))
-      / (sum without (status, aggregation_id) (rate(facilitator_intake_tasks_finished[1h]))) > 0.10
+    expr: (sum without (status, aggregation_id, instance, node) (rate(facilitator_intake_tasks_finished{status="rejected"}[1h])))
+      / (sum without (status, aggregation_id, instance, node) (rate(facilitator_intake_tasks_finished[1h]))) > 0.10
     for: 5m
     labels:
       severity: page
@@ -55,8 +55,8 @@ groups:
         {{ $labels.service }} in environment ${environment} has
         rejected more than 10% of tasks in the last hour"
   - alert: facilitator_aggregate_rejection_rate
-    expr: (sum without (status, aggregation_id) (rate(facilitator_aggregate_tasks_finished{status="rejected"}[${aggregation_period}])))
-      / (sum without (status, aggregation_id) (rate(facilitator_aggregate_tasks_finished[${aggregation_period}]))) > 0.01
+    expr: (sum without (status, aggregation_id, instance, node) (rate(facilitator_aggregate_tasks_finished{status="rejected"}[${aggregation_period}])))
+      / (sum without (status, aggregation_id, instance, node) (rate(facilitator_aggregate_tasks_finished[${aggregation_period}]))) > 0.01
     for: 5m
     labels:
       severity: page


### PR DESCRIPTION
This is a follow-up to #2413, to address further false positives from alerts. This change additionally aggregates away the `instance` and `node` labels. Due to random chance, individual pods in a deployment could process a small number of reports with more than 10% encrypted to expired keys. Summing over this label smooths out that variation. We don't need to monitor these errors on a pod-by-pod basis, since they are autoscaled.