### PR TITLE
Update EKS plugins for 1.23

### DIFF
--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -35,7 +35,7 @@ cluster_settings = {
   max_node_count      = 3
   gcp_machine_type    = "e2-standard-2"
   aws_machine_types   = ["t3.large"]
-  eks_cluster_version = "1.22"
+  eks_cluster_version = "1.23"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
   eks_vpc_cni_addon_version = "v1.11.4-eksbuild.1"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#updating-ebs-csi-eks-add-on

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -37,11 +37,11 @@ cluster_settings = {
   aws_machine_types   = ["t3.large"]
   eks_cluster_version = "1.23"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
-  eks_vpc_cni_addon_version = "v1.11.4-eksbuild.1"
+  eks_vpc_cni_addon_version = "v1.12.2-eksbuild.1"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#updating-ebs-csi-eks-add-on
-  eks_ebs_csi_addon_version = "v1.13.0-eksbuild.2"
-  # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.22.1
-  eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.1"
+  eks_ebs_csi_addon_version = "v1.16.0-eksbuild.1"
+  # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.23.0
+  eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.0"
 }
 is_first                 = false
 use_aws                  = true

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -67,7 +67,7 @@ cluster_settings = {
   max_node_count      = 3
   gcp_machine_type    = "e2-standard-2"
   aws_machine_types   = ["t3.medium"]
-  eks_cluster_version = "1.22"
+  eks_cluster_version = "1.23"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
   eks_vpc_cni_addon_version = "v1.11.4-eksbuild.1"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#updating-ebs-csi-eks-add-on

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -69,11 +69,11 @@ cluster_settings = {
   aws_machine_types   = ["t3.medium"]
   eks_cluster_version = "1.23"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
-  eks_vpc_cni_addon_version = "v1.11.4-eksbuild.1"
+  eks_vpc_cni_addon_version = "v1.12.2-eksbuild.1"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#updating-ebs-csi-eks-add-on
-  eks_ebs_csi_addon_version = "v1.13.0-eksbuild.2"
-  # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.22.1
-  eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.1"
+  eks_ebs_csi_addon_version = "v1.16.0-eksbuild.1"
+  # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.23.0
+  eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.0"
 }
 test_peer_environment = {
   env_with_ingestor    = "stg-us-facil"


### PR DESCRIPTION
This updates the EBS and VPC add-ons and the cluster autoscaler to recent ones compatible with 1.23. Because we are only doing a single minor version upgrade of the VPC CNI plugin, we don't need to perform any manual updates.