### PR TITLE
Update EKS to 1.23 in production

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -97,7 +97,7 @@ cluster_settings = {
   max_node_count      = 6
   gcp_machine_type    = "e2-standard-2"
   aws_machine_types   = ["t3.large"]
-  eks_cluster_version = "1.22"
+  eks_cluster_version = "1.23"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
   eks_vpc_cni_addon_version = "v1.11.4-eksbuild.1"
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#updating-ebs-csi-eks-add-on


### PR DESCRIPTION
AWS is deprecating EKS 1.22 in early June, but we need to continue running the international instance of ENPA through the end of that month, so we update to 1.23.