### PR TITLE
Update IAM policy for EKS cluster autoscaler

### DIFF
--- a/terraform/modules/eks/cluster_autoscaler.tf
+++ b/terraform/modules/eks/cluster_autoscaler.tf
@@ -35,13 +35,25 @@ resource "aws_iam_role_policy" "cluster_autoscaler" {
     Statement = [
       {
         Action = [
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:TerminateInstanceInAutoScalingGroup",
+        ]
+        Resource = "*"
+        Effect   = "Allow"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/k8s.io/cluster-autoscaler/${data.aws_eks_cluster.cluster.name}" = "owned"
+          }
+        }
+      },
+      {
+        Action = [
           "autoscaling:DescribeAutoScalingGroups",
           "autoscaling:DescribeAutoScalingInstances",
           "autoscaling:DescribeLaunchConfigurations",
           "autoscaling:DescribeTags",
-          "autoscaling:SetDesiredCapacity",
-          "autoscaling:TerminateInstanceInAutoScalingGroup",
           "ec2:DescribeLaunchTemplateVersions",
+          "ec2:DescribeInstanceTypes",
         ]
         Resource = "*"
         Effect   = "Allow"


### PR DESCRIPTION
The 1.23 Kubernetes cluster autoscaler needs one more permission in the AWS IAM policy granted to its role to function. The current documentation ([1]) also suggests restricting some of the existing permissions to only act on specific clusters, so we do that, too.

[1]: https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html