### PR TITLE
Switch to registry.k8s.io

### DIFF
--- a/terraform/modules/monitoring/monitoring.tf
+++ b/terraform/modules/monitoring/monitoring.tf
@@ -423,6 +423,12 @@ resource "helm_release" "prometheus" {
     name  = "pushgateway.image.tag"
     value = "v1.5.1"
   }
+
+  # Pull from registry.k8s.io instead of k8s.gcr.io
+  set {
+    name  = "kube-state-metrics.image.repository"
+    value = "registry.k8s.io/kube-state-metrics/kube-state-metrics"
+  }
 }
 
 # Configures Grafana to get data from Prometheus. The label on this config map

--- a/terraform/modules/nfs_server/nfs_server.tf
+++ b/terraform/modules/nfs_server/nfs_server.tf
@@ -38,7 +38,7 @@ resource "kubernetes_deployment_v1" "nfs-server" {
       spec {
         container {
           name  = "nfs-server"
-          image = "k8s.gcr.io/volume-nfs:0.8"
+          image = "registry.k8s.io/volume-nfs:0.8"
           port {
             name           = "nfs"
             container_port = 2049

--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -103,7 +103,7 @@ cluster_settings = {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#updating-ebs-csi-eks-add-on
   eks_ebs_csi_addon_version = "v1.16.0-eksbuild.1"
   # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.23.0
-  eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.0"
+  eks_cluster_autoscaler_version = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.23.0"
 }
 is_first                 = false
 use_aws                  = true

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -41,7 +41,7 @@ cluster_settings = {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#updating-ebs-csi-eks-add-on
   eks_ebs_csi_addon_version = "v1.16.0-eksbuild.1"
   # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.23.0
-  eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.0"
+  eks_cluster_autoscaler_version = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.23.0"
 }
 is_first                 = false
 use_aws                  = true

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -73,7 +73,7 @@ cluster_settings = {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#updating-ebs-csi-eks-add-on
   eks_ebs_csi_addon_version = "v1.16.0-eksbuild.1"
   # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.23.0
-  eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.0"
+  eks_cluster_autoscaler_version = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.23.0"
 }
 test_peer_environment = {
   env_with_ingestor    = "stg-us-facil"


### PR DESCRIPTION
This switches three container images to be pulled from `registry.k8s.io` instead of `k8s.gcr.io`. The latter will be sunsetted, see https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/. Using `registry.k8s.io` lets us fetch from a more-local backend on AWS clusters.