### PR TITLE
Give key-rotator a toleration for spot VM taints

### DIFF
--- a/terraform/modules/kubernetes_locality/kubernetes_locality.tf
+++ b/terraform/modules/kubernetes_locality/kubernetes_locality.tf
@@ -243,6 +243,14 @@ resource "kubernetes_cron_job" "key_rotator" {
         template {
           metadata {}
           spec {
+            # Allow key-rotator to run on both spot and non-spot nodes, with
+            # no preference.
+            toleration {
+              key      = "divviup.org/spot-vm"
+              operator = "Exists"
+              effect   = "NoSchedule"
+            }
+
             container {
               name  = "key-rotator"
               image = "${var.container_registry}/${var.key_rotator_image}:${var.key_rotator_version}"


### PR DESCRIPTION
This adds a toleration for `divviup.org/spot-vm` to the key rotation CronJob. This should hopefully help with the scheduling issues we've had over the past two days. Key rotation runs fast enough that using a spot instance should not be of concern.