### PR TITLE
Add Nevada

### DIFF
--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -2,7 +2,7 @@ environment     = "prod-us"
 state_bucket    = "prod-us-us-west1-prio-terraform"
 gcp_region      = "us-west1"
 gcp_project     = "prio-prod-us"
-localities      = ["ta-ta", "us-ct", "us-md", "us-va", "us-wa", "us-ca", "us-ut", "us-wi", "us-ma", "us-nm", "us-hi", "us-co", "us-dc", "us-la", "us-mo", "us-ak"]
+localities      = ["ta-ta", "us-ct", "us-md", "us-va", "us-wa", "us-ca", "us-ut", "us-wi", "us-ma", "us-nm", "us-hi", "us-co", "us-dc", "us-la", "us-mo", "us-ak", "us-nv"]
 aws_region      = "us-west-1"
 manifest_domain = "isrg-prio.org"
 managed_dns_zone = {
@@ -115,6 +115,12 @@ ingestors = {
         min_aggregate_worker_count = 1
         max_aggregate_worker_count = 3
       }
+      us-nv = {
+        min_intake_worker_count    = 1
+        max_intake_worker_count    = 12
+        min_aggregate_worker_count = 1
+        max_aggregate_worker_count = 3
+      }
     }
   }
   g-enpa = {
@@ -215,6 +221,12 @@ ingestors = {
         max_aggregate_worker_count = 3
       }
       us-ak = {
+        min_intake_worker_count    = 1
+        max_intake_worker_count    = 6
+        min_aggregate_worker_count = 1
+        max_aggregate_worker_count = 3
+      }
+      us-nv = {
         min_intake_worker_count    = 1
         max_intake_worker_count    = 6
         min_aggregate_worker_count = 1


### PR DESCRIPTION
This deploys infrastructure for Nevada's locality. We need to wait for the ingestor's manifest to be set up, at https://storage.googleapis.com/prio-manifests/us-nv-g-enpa-manifest.json, before we can deploy this.