### PR TITLE
Deploy 0.6.95 to prod-intl

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -108,9 +108,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-workflow_manager_version = "0.6.94"
-facilitator_version      = "0.6.94"
-key_rotator_version      = "0.6.94"
+workflow_manager_version = "0.6.95"
+facilitator_version      = "0.6.95"
+key_rotator_version      = "0.6.95"
 victorops_routing_key    = "prio-prod-intl"
 
 default_aggregation_period       = "8h"


### PR DESCRIPTION
We are no longer deploying to prod-us because NCI's side has been torn down.